### PR TITLE
STS integration - making changes to the plugin and plugin unit tests

### DIFF
--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
@@ -20,6 +20,4 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 
 public interface Builder extends CopyableBuilder<Builder, S3AccessGrantsPlugin> {
 
-    Builder accountId(String accountId);
-
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -15,19 +15,19 @@ public class S3AccessGrantsPluginTests {
 
     @Test
     public void create_access_grants_plugin() {
-       Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder().accountId(TEST_ACCOUNT).build());
+       Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder().build());
     }
 
     @Test
     public void create_access_grants_plugin_from_existing_plugin() {
-        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().accountId(TEST_ACCOUNT).build();
+        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
     }
 
     @Test
     public void create_access_grants_rebuild_plugin_from_existing_plugin() {
-        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().accountId(TEST_ACCOUNT).build();
-        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.toBuilder().accountId(TEST_ACCOUNT).build());
+        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
+        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.toBuilder().build());
     }
 
     @Test
@@ -102,7 +102,5 @@ public class S3AccessGrantsPluginTests {
                 .hasMessage("Expecting a region to be configured on the S3Clients!");
 
     }
-
-
 
 }


### PR DESCRIPTION
**Motivation and Context**
Changing the plugin configuration settings to no longer accept accountID from the requester.

**Description of changes:**
- Changed the Builder to no longer consider accountID as an input.
- Changed the plugin implementation to build and pass on an STS client to the identity providers.
- Updated the unit tests to reflect the updates in the plugin configuration.

License
[ X ] I confirm that this pull request can be released under the Apache 2 license
