### PR TITLE
updating the plugin tests after recent SDK release + removing extra dependencies in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.20.2</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -111,12 +110,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch-metric-publisher</artifactId>
             <version>2.21.30</version>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.20.2</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.s3accessgrants.plugin;
 import org.junit.Test;
 import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.core.SdkServiceClientConfiguration;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -120,8 +121,9 @@ public class S3AccessGrantsPluginTests {
 
 
         Assertions.assertThatThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Expecting a region to be configured on the S3Clients!");
+                .isInstanceOf(SdkClientException.class);
+        // SDK supports default values for the plugin as well, which bypasses the custom validation.
+        // SDK will throw SdkClientException when it attempts to look for the credentials in the environment config and does not find any.
 
     }
 


### PR DESCRIPTION
*Issue #, if available:*
CI/CD build tests are erroring out after a recent update in AWS SDK V2. The SDK now turns on default settings on the plugin if the settings are not explicitly specified.

*Description of changes:*
* Updating the unit tests for the plugin in accordance with the AWS SDK V2 changes.
* removing an duplicate dependency in the pom.xml file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
