### PR TITLE
Adding cross-region bucket access support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ In order to turn on the cross-region support, please configure S3Client and Acce
                         .build();
 ```
 
+#### NOTE - 
+If cross-region access setting is turned on for either the S3 Client or the plugin (but not both), you might experience bucket region mismatch errors.
+
 ### Cross-account support
 
 The plugin makes S3 head bucket requests to determine bucket location. 
-In case of cross-account access S3 expects s3:ListBucket permission for the requesting account on the requested bucket. Please add the necessary permission if the plugin will be used for cross-region access.
+In case of cross-account access S3 expects s3:ListBucket permission for the requesting account on the requested bucket. Please add the necessary permission if the plugin will be used for cross-account access.
 
 ### Turn on metrics
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Create a S3AccessGrantsPlugin object and choose if you want to enable fallback.
 1.  If enableFallback option is set to false we will fallback only in case the operation/API is not supported by Access Grants.
 2.  If enableFallback is set to true then we will fall back every time we are not able to get the credentials from Access Grants, no matter the reason.
 
-
 ```
 S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableFallback(true).build();
 ```
@@ -65,6 +64,29 @@ S3Client s3Client = S3Client.builder()
 ````
 
 Using this S3Client to make API calls, you should be able to use Access Grants to get access to your resources.
+
+### Turn on cross-region access
+
+The plugin by default does not support cross-region access of S3 Buckets/data. 
+In order to turn on the cross-region support, please configure S3Client and Access Grants Plugin to support cross-region access.
+
+```
+ S3AccessGrantsPlugin accessGrantsPlugin =
+                S3AccessGrantsPlugin.builder().enableCrossRegionAccess(Boolean.TRUE).build();
+
+        S3Client s3Client =
+                S3Client.builder()
+                        .crossRegionAccessEnabled(true)
+                        .credentialsProvider(credentialsProvider)
+                        .addPlugin(accessGrantsPlugin)
+                        .region(S3AccessGrantsIntegrationTestsUtils.TEST_REGION)
+                        .build();
+```
+
+### Cross-account support
+
+The plugin makes S3 head bucket requests to determine bucket location. 
+In case of cross-account access S3 expects s3:ListBucket permission for the requesting account on the requested bucket. Please add the necessary permission if the plugin will be used for cross-region access.
 
 ### Turn on metrics
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sdk.version>2.22.3</sdk.version>
     </properties>
 
     <scm>
@@ -52,12 +53,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-auth-spi</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
@@ -67,7 +68,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>identity-spi</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -94,22 +95,22 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3control</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch-metric-publisher</artifactId>
-            <version>2.21.30</version>
+            <version>${sdk.version}</version>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
@@ -72,7 +72,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.*;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.BUCKET_LOCATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
 
 /** Readme.md (will be moved to readme or contributing guide in the repo)

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
@@ -136,7 +136,7 @@ public class S3AccessGrantsIntegrationTests {
     @AfterClass
     public static void tearDown() {
         if (!S3AccessGrantsIntegrationTestsUtils.DISABLE_TEAR_DOWN) {
-//            S3AccessGrantsInstanceSetUpUtils.tearDown();
+            S3AccessGrantsInstanceSetUpUtils.tearDown();
         }
     }
 

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
@@ -147,7 +147,7 @@ public class S3AccessGrantsIntegrationTests {
     @AfterClass
     public static void tearDown() {
         if (!S3AccessGrantsIntegrationTestsUtils.DISABLE_TEAR_DOWN) {
-            S3AccessGrantsInstanceSetUpUtils.tearDown();
+//            S3AccessGrantsInstanceSetUpUtils.tearDown();
         }
     }
 

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
@@ -15,19 +15,24 @@
 
 package software.amazon.awssdk.s3accessgrants.plugin;
 
-import software.amazon.awssdk.identity.spi.IdentityProperty;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.*;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.utils.Logger;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketResponse;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
@@ -15,8 +15,10 @@
 
 package software.amazon.awssdk.s3accessgrants.plugin;
 
+import software.amazon.awssdk.identity.spi.IdentityProperty;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.*;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.utils.Logger;
 
 import java.io.FileInputStream;
@@ -67,6 +69,8 @@ public class S3AccessGrantsIntegrationTestsUtils {
 
     public static Region TEST_REGION;
 
+    public static Region TEST_REGION_2;
+
     public static String TEST_CREDENTIALS_PROFILE_NAME;
 
     public static String TEST_ACCOUNT;
@@ -76,6 +80,8 @@ public class S3AccessGrantsIntegrationTestsUtils {
     public static final String TEST_BUCKET_NAME_NOT_REGISTERED = "access-grants-sdk-test-bucket-not-registered";
 
     public static final String TEST_BUCKET_READWRITE = "access-grants-sdk-test-bucket-readwrite";
+
+    public static final String TEST_BUCKET_READWRITE_CROSS_REGION = "access-grants-sdk-test-bucket-readwrite-cross-region";
 
     public static final String TEST_LOCATION_1 = "PrefixA/prefixB/";
 
@@ -133,9 +139,18 @@ public class S3AccessGrantsIntegrationTestsUtils {
 
     }
 
-    public static S3ControlAsyncClient s3ControlAsyncClientBuilder(IdentityProvider<AwsCredentialsIdentity> identityProvider,
-                                                                   Region region) {
+    public static S3ControlAsyncClientBuilder s3ControlAsyncClientBuilder(IdentityProvider<AwsCredentialsIdentity> identityProvider,
+                                                                          Region region) {
         return S3ControlAsyncClient.builder()
+                .region(region)
+                .credentialsProvider(identityProvider);
+
+    }
+
+    public static S3Client s3ClientBuilder(IdentityProvider<AwsCredentialsIdentity> identityProvider,
+                                           Region region) {
+
+        return S3Client.builder()
                 .region(region)
                 .credentialsProvider(identityProvider)
                 .build();

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTestsUtils.java
@@ -16,7 +16,13 @@
 package software.amazon.awssdk.s3accessgrants.plugin;
 
 import software.amazon.awssdk.services.iam.IamClient;
-import software.amazon.awssdk.services.iam.model.*;
+import software.amazon.awssdk.services.iam.model.CreatePolicyRequest;
+import software.amazon.awssdk.services.iam.model.EntityAlreadyExistsException;
+import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
+import software.amazon.awssdk.services.iam.model.AttachRolePolicyRequest;
+import software.amazon.awssdk.services.iam.model.DeletePolicyRequest;
+import software.amazon.awssdk.services.iam.model.DeleteRoleRequest;
+import software.amazon.awssdk.services.iam.model.DetachRolePolicyRequest;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.utils.Logger;
 

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsAccountIdResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsAccountIdResolver.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.s3accessgrants.cache;
 
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 
 public interface S3AccessGrantsAccountIdResolver {
@@ -22,8 +23,9 @@ public interface S3AccessGrantsAccountIdResolver {
      *
      * @param accountId AWS AccountId from the request context parameter
      * @param s3Prefix e.g., s3://bucket-name/path/to/helloworld.txt
+     * @param s3ControlAsyncClient S3ControlAsynClient that will be used for making the requests
      * @return AWS AccountId of the S3 Access Grants Instance that owns the location scope of the s3Prefix
      * @throws S3ControlException propagate S3ControlException from service call
      */
-    String resolve(String accountId, String s3Prefix) throws S3ControlException;
+    String resolve(String accountId, String s3Prefix, S3ControlAsyncClient s3ControlAsyncClient) throws S3ControlException;
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
@@ -1,0 +1,20 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
+import software.amazon.awssdk.services.s3control.model.S3ControlException;
+
+public interface S3AccessGrantsBucketRegionResolver {
+
+    /**
+     *
+     * @param bucket name of the bucket being accessed
+     * @param s3Client s3client that will be used for making the requests
+     * @throws S3Exception propagate S3Exception from service call
+     */
+
+    Region resolve(String bucket, S3Client s3Client) throws S3Exception;
+
+}

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package software.amazon.awssdk.s3accessgrants.cache;
 
 import software.amazon.awssdk.regions.Region;
@@ -11,10 +25,9 @@ public interface S3AccessGrantsBucketRegionResolver {
     /**
      *
      * @param bucket name of the bucket being accessed
-     * @param s3Client s3client that will be used for making the requests
      * @throws S3Exception propagate S3Exception from service call
      */
 
-    Region resolve(String bucket, S3Client s3Client) throws S3Exception;
+    Region resolve(String bucket) throws S3Exception;
 
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCache.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCache.java
@@ -71,7 +71,6 @@ public class S3AccessGrantsCache {
     public interface Builder {
         S3AccessGrantsCache build();
         S3AccessGrantsCache buildWithAccountIdResolver();
-        S3AccessGrantsCache.Builder s3ControlAsyncClient(S3ControlAsyncClient s3ControlAsyncClient);
         S3AccessGrantsCache.Builder maxCacheSize(int maxCacheSize);
         S3AccessGrantsCache.Builder cacheExpirationTimePercentage(int cacheExpirationTimePercentage);
         S3AccessGrantsCache.Builder s3AccessGrantsCachedAccountIdResolver(S3AccessGrantsCachedAccountIdResolver s3AccessGrantsCachedAccountIdResolver);
@@ -98,12 +97,6 @@ public class S3AccessGrantsCache {
                     return new S3AccessGrantsCache(s3AccessGrantsCachedAccountIdResolver, maxCacheSize,
                                                    cacheExpirationTimePercentage);
                 }
-
-        @Override
-        public Builder s3ControlAsyncClient(S3ControlAsyncClient s3ControlAsyncClient) {
-            this.s3ControlAsyncClient = s3ControlAsyncClient;
-            return this;
-        }
 
         @Override
         public Builder maxCacheSize(int maxCacheSize) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
@@ -117,8 +117,6 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
     public interface Builder {
         S3AccessGrantsCachedAccountIdResolver build();
 
-        Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient);
-
         Builder maxCacheSize(int maxCacheSize);
 
         Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds);
@@ -135,12 +133,6 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
         public BuilderImpl(S3AccessGrantsCachedAccountIdResolver s3AccessGrantsCachedAccountIdResolver) {
             maxCacheSize(s3AccessGrantsCachedAccountIdResolver.maxCacheSize);
             expireCacheAfterWriteSeconds(s3AccessGrantsCachedAccountIdResolver.expireCacheAfterWriteSeconds);
-        }
-
-        @Override
-        public Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient) {
-            this.S3ControlAsyncClient = S3ControlAsyncClient;
-            return this;
         }
 
         public int maxCacheSize() {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
@@ -1,0 +1,170 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.utils.Logger;
+
+import java.time.Duration;
+
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
+
+public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsBucketRegionResolver{
+
+
+    private int maxCacheSize;
+
+    private int expireCacheAfterWriteSeconds;
+
+    private static Cache<String, Region> cache;
+
+    public int getMaxCacheSize() {
+        return maxCacheSize;
+    }
+
+
+    public int getExpireCacheAfterWriteSeconds() {
+        return expireCacheAfterWriteSeconds;
+    }
+
+    private S3Client s3Client;
+
+    private static final Logger logger = Logger.loggerFor(S3AccessGrantsCachedBucketRegionResolver.class);
+
+    public int maxCacheSize() {
+        return maxCacheSize;
+    }
+
+    public int expireCacheAfterWriteSeconds() {
+        return expireCacheAfterWriteSeconds;
+    }
+
+    protected CacheStats getCacheStats() { return cache.stats(); }
+
+    S3AccessGrantsCachedBucketRegionResolver() {
+        this.maxCacheSize = BUCKET_REGION_CACHE_SIZE;
+        this.expireCacheAfterWriteSeconds = BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+    }
+
+
+    public S3AccessGrantsCachedBucketRegionResolver.Builder toBuilder() {
+        return new S3AccessGrantsCachedBucketRegionResolver.BuilderImpl(this);
+    }
+
+    public static S3AccessGrantsCachedBucketRegionResolver.Builder builder() {
+        return new S3AccessGrantsCachedBucketRegionResolver.BuilderImpl();
+    }
+
+    @Override
+    public Region resolve(String bucket, S3Client s3Client) throws S3Exception {
+
+        this.s3Client = s3Client;
+        Region bucketRegion = cache.getIfPresent(bucket);
+        if(bucketRegion == null) {
+            logger.debug(() -> "bucket region not available in cache, fetching the region from the service!");
+            if (s3Client == null) {
+                throw new IllegalArgumentException("S3Client is required for the bucket region resolver!");
+            }
+            bucketRegion = resolveFromService(bucket);
+            if(bucketRegion != null) {
+                cache.put(bucket, bucketRegion);
+            }
+        } else {
+            logger.debug(() -> "bucket region available in cache!");
+        }
+        return bucketRegion;
+
+    }
+
+    private Region resolveFromService(String bucket) {
+        String resolvedRegion = null;
+        try {
+                logger.info(() -> "making a call to S3 for determining the bucket region!");
+                HeadBucketRequest bucketLocationRequest = HeadBucketRequest.builder().bucket(bucket).build();
+                HeadBucketResponse headBucketResponse = s3Client.headBucket(bucketLocationRequest);
+                resolvedRegion = headBucketResponse.bucketRegion();
+        } catch (S3Exception e) {
+            if (e.statusCode() == 301) {
+                // A fallback in case S3 Clients are not able to re-direct the head bucket requests to the correct region.
+                String bucketRegion = e.awsErrorDetails().sdkHttpResponse().headers().get("x-amz-bucket-region").get(0);
+                resolvedRegion = bucketRegion;
+            } else {
+                throw e;
+            }
+        }
+        if(resolvedRegion == null) throw SdkServiceException.builder().message("S3 error! region cannot be determined for the specified bucket!").build();
+        return Region.of(resolvedRegion);
+    }
+
+
+    public interface Builder {
+        S3AccessGrantsCachedBucketRegionResolver build();
+
+        S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize);
+
+        S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds);
+    }
+
+    static final class BuilderImpl implements S3AccessGrantsCachedBucketRegionResolver.Builder {
+        private int maxCacheSize = BUCKET_REGION_CACHE_SIZE;
+        private int expireCacheAfterWriteSeconds = BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+
+        private BuilderImpl() {
+        }
+
+        public BuilderImpl(S3AccessGrantsCachedBucketRegionResolver s3AccessGrantsCachedBucketRegionResolver) {
+            maxCacheSize(s3AccessGrantsCachedBucketRegionResolver.maxCacheSize);
+            expireCacheAfterWriteSeconds(s3AccessGrantsCachedBucketRegionResolver.expireCacheAfterWriteSeconds);
+        }
+
+        public int maxCacheSize() {
+            return maxCacheSize;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize) {
+            if (maxCacheSize <= 0 || maxCacheSize > MAX_BUCKET_REGION_CACHE_SIZE) {
+                throw new IllegalArgumentException(String.format("maxCacheSize needs to be in range (0, %d]",
+                        MAX_BUCKET_REGION_CACHE_SIZE));
+            }
+            this.maxCacheSize = maxCacheSize;
+            return this;
+        }
+
+        public int expireCacheAfterWriteSeconds() {
+            return expireCacheAfterWriteSeconds;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds) {
+            if (expireCacheAfterWriteSeconds <= 0 || expireCacheAfterWriteSeconds > MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS) {
+                throw new IllegalArgumentException(String.format("expireCacheAfterWriteSeconds needs to be in range (0, %d]",
+                        MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS));
+            }
+            this.expireCacheAfterWriteSeconds = expireCacheAfterWriteSeconds;
+            return this;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver build() {
+            S3AccessGrantsCachedBucketRegionResolver resolver = new S3AccessGrantsCachedBucketRegionResolver();
+            resolver.maxCacheSize = maxCacheSize();
+            resolver.expireCacheAfterWriteSeconds = expireCacheAfterWriteSeconds();
+            resolver.cache = Caffeine.newBuilder()
+                    .maximumSize(maxCacheSize)
+                    .expireAfterWrite(Duration.ofSeconds(expireCacheAfterWriteSeconds))
+                    .build();
+            return resolver;
+        }
+    }
+
+}

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
@@ -32,6 +32,10 @@ import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstant
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
 
+/*
+* A layer for caching bucket regions.
+* This cache is specifically to avoid head bucket throttling.
+* */
 public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsBucketRegionResolver {
 
 
@@ -151,6 +155,10 @@ public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsB
             return s3Client;
         }
 
+        public int expireCacheAfterWriteSeconds() {
+            return expireCacheAfterWriteSeconds;
+        }
+
         @Override
         public S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize) {
             if (maxCacheSize <= 0 || maxCacheSize > MAX_BUCKET_REGION_CACHE_SIZE) {
@@ -162,16 +170,12 @@ public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsB
         }
 
         @Override
-        public Builder s3Client(S3Client s3Client) {
-            if(s3Client == null) throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
+        public S3AccessGrantsCachedBucketRegionResolver.Builder s3Client(S3Client s3Client) {
+            if (s3Client == null)
+                throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
             this.s3Client = s3Client;
             return this;
         }
-
-        public int expireCacheAfterWriteSeconds() {
-            return expireCacheAfterWriteSeconds;
-        }
-
         @Override
         public S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds) {
             if (expireCacheAfterWriteSeconds <= 0 || expireCacheAfterWriteSeconds > MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProvider.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.s3accessgrants.cache;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.services.s3control.model.Permission;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 
@@ -27,11 +28,12 @@ public interface S3AccessGrantsCachedCredentialsProvider {
      * @param credentials Credentials used for calling Access Grants.
      * @param permission Permission requested by the user. Can be Read, Write, or ReadWrite.
      * @param s3Prefix S3Prefix requested by the user. e.g., s3://bucket-name/path/to/helloworld.txt
+     * @param s3ControlAsyncClient S3ControlAsynClient that will be used for making the requests
      * @return Credentials from Access Grants.
      * @throws S3ControlException in-case exception is cached.
      */
     CompletableFuture<AwsCredentialsIdentity> getDataAccess (AwsCredentialsIdentity credentials, Permission permission, String s3Prefix,
-                                                             String accountId) throws Exception;
+                                                             String accountId, S3ControlAsyncClient s3ControlAsyncClient) throws Exception;
 
     /**
      * @return metrics collected by access grants cache jar

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
@@ -33,17 +33,16 @@ import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstant
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_LIMIT_ACCESS_GRANTS_MAX_CACHE_SIZE;
 
-public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGrantsCachedCredentialsProvider{
+public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGrantsCachedCredentialsProvider {
 
     private final S3AccessGrantsCache accessGrantsCache;
     private final S3AccessGrantsAccessDeniedCache s3AccessGrantsAccessDeniedCache;
     DefaultMetricCollector collector = new DefaultMetricCollector("AccessGrantsMetricsCollector");
     public static final Logger logger = Logger.loggerFor(S3AccessGrantsCachedCredentialsProviderImpl.class);
 
-    private S3AccessGrantsCachedCredentialsProviderImpl(S3ControlAsyncClient S3ControlAsyncClient, int maxCacheSize, int cacheExpirationTimePercentage) {
+    private S3AccessGrantsCachedCredentialsProviderImpl(int maxCacheSize, int cacheExpirationTimePercentage) {
 
         accessGrantsCache = S3AccessGrantsCache.builder()
-                                               .s3ControlAsyncClient(S3ControlAsyncClient)
                                                .maxCacheSize(maxCacheSize)
                                                .cacheExpirationTimePercentage(cacheExpirationTimePercentage).build();
 
@@ -52,11 +51,10 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
     }
 
     @VisibleForTesting
-    S3AccessGrantsCachedCredentialsProviderImpl(S3ControlAsyncClient s3ControlAsyncClient,
-                                                        S3AccessGrantsCachedAccountIdResolver resolver,int maxCacheSize, int cacheExpirationTimePercentage) {
+    S3AccessGrantsCachedCredentialsProviderImpl(S3AccessGrantsCachedAccountIdResolver resolver,
+                                                int maxCacheSize, int cacheExpirationTimePercentage) {
 
         accessGrantsCache = S3AccessGrantsCache.builder()
-                                               .s3ControlAsyncClient(s3ControlAsyncClient)
                                                .maxCacheSize(maxCacheSize)
                                                .cacheExpirationTimePercentage(cacheExpirationTimePercentage)
                                                .s3AccessGrantsCachedAccountIdResolver(resolver)
@@ -89,12 +87,12 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
 
         @Override
         public S3AccessGrantsCachedCredentialsProviderImpl build() {
-            return new S3AccessGrantsCachedCredentialsProviderImpl(S3ControlAsyncClient, maxCacheSize, cacheExpirationTimePercentage);
+            return new S3AccessGrantsCachedCredentialsProviderImpl(maxCacheSize, cacheExpirationTimePercentage);
         }
 
         @Override
         public S3AccessGrantsCachedCredentialsProviderImpl buildWithAccountIdResolver() {
-            return new S3AccessGrantsCachedCredentialsProviderImpl(S3ControlAsyncClient, s3AccessGrantsCachedAccountIdResolver, maxCacheSize, cacheExpirationTimePercentage);
+            return new S3AccessGrantsCachedCredentialsProviderImpl(s3AccessGrantsCachedAccountIdResolver, maxCacheSize, cacheExpirationTimePercentage);
         }
 
         @Override
@@ -131,8 +129,8 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
     }
 
     @Override
-    public CompletableFuture<AwsCredentialsIdentity> getDataAccess (AwsCredentialsIdentity credentials, Permission permission,
-                                                                    String s3Prefix, @NotNull String accountId) throws S3ControlException {
+    public CompletableFuture<AwsCredentialsIdentity> getDataAccess(AwsCredentialsIdentity credentials, Permission permission,
+                                                                   String s3Prefix, @NotNull String accountId, S3ControlAsyncClient s3ControlAsyncClient) throws S3ControlException {
 
         Instant start = Instant.now();
         CacheKey cacheKey = CacheKey.builder()
@@ -149,7 +147,7 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
 
         CompletableFuture<AwsCredentialsIdentity> accessGrantsCredentials;
         try {
-            accessGrantsCredentials = accessGrantsCache.getCredentials(cacheKey, accountId, s3AccessGrantsAccessDeniedCache);
+            accessGrantsCredentials = accessGrantsCache.getCredentials(cacheKey, accountId, s3AccessGrantsAccessDeniedCache, s3ControlAsyncClient);
         }catch (S3ControlException e) {
             collector.reportMetric(MetricsCollector.ERROR_COUNT,1);
             throw e;

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
@@ -70,7 +70,6 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
     public interface Builder {
         S3AccessGrantsCachedCredentialsProviderImpl build();
         S3AccessGrantsCachedCredentialsProviderImpl buildWithAccountIdResolver();
-        S3AccessGrantsCachedCredentialsProviderImpl.Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient);
         S3AccessGrantsCachedCredentialsProviderImpl.Builder s3AccessGrantsCachedAccountIdResolver(S3AccessGrantsCachedAccountIdResolver s3AccessGrantsCachedAccountIdResolver);
         S3AccessGrantsCachedCredentialsProviderImpl.Builder maxCacheSize(int maxCacheSize);
         S3AccessGrantsCachedCredentialsProviderImpl.Builder cacheExpirationTimePercentage(int cacheExpirationTimePercentage);
@@ -93,12 +92,6 @@ public class S3AccessGrantsCachedCredentialsProviderImpl implements S3AccessGran
         @Override
         public S3AccessGrantsCachedCredentialsProviderImpl buildWithAccountIdResolver() {
             return new S3AccessGrantsCachedCredentialsProviderImpl(s3AccessGrantsCachedAccountIdResolver, maxCacheSize, cacheExpirationTimePercentage);
-        }
-
-        @Override
-        public S3AccessGrantsCachedCredentialsProviderImpl.Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient) {
-            this.S3ControlAsyncClient = S3ControlAsyncClient;
-            return this;
         }
 
         @Override

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.s3accessgrants.cache;
 public class S3AccessGrantsConstants {
     public static final int DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE = 1_000;
     public static final int MAX_LIMIT_ACCOUNT_ID_MAX_CACHE_SIZE = 1_000_000;
-    public static final int DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 86_400; // one day
+    public static final int DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 6_00; // 10 mins
     public static final int MAX_LIMIT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 2_592_000; // 30 days
 
     public static final int DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE = 30_000;

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
@@ -27,4 +27,12 @@ public class S3AccessGrantsConstants {
 
     public static final int ACCESS_DENIED_CACHE_SIZE = 3_000;
 
+    public static final int BUCKET_REGION_CACHE_SIZE = 1_000;
+
+    public static final int MAX_BUCKET_REGION_CACHE_SIZE = 1_000_000;
+
+    public static final int MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 6_00; // 10 mins
+
+    public static final int BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS= 3_00; // 5 mins
+
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
@@ -20,4 +20,6 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 
 public interface Builder extends CopyableBuilder<Builder, S3AccessGrantsPlugin> {
     Builder enableFallback(Boolean choice);
+
+    Builder enableCrossRegionAccess(Boolean choice);
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -17,15 +17,29 @@ package software.amazon.awssdk.s3accessgrants.plugin;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.annotations.NotNull;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsOperationToPermissionMapper;
+import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsStaticOperationToPermissionMapper;
 import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeParams;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3control.model.Permission;
 
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.BUCKET_LOCATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.logger;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.CONTACT_TEAM_MESSAGE_TEMPLATE;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.DEFAULT_CROSS_REGION_ACCESS_SETTING;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.AUTH_EXCEPTIONS_PROPERTY;
 
 
 /**
@@ -37,10 +51,20 @@ import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGran
 public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
 
     private final S3AuthSchemeProvider authSchemeProvider;
-    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider) {
+    private final S3Client s3Client;
+
+    private final Boolean isCrossRegionAccessEnabled;
+
+    private final S3AccessGrantsOperationToPermissionMapper permissionMapper;
+
+    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider, S3Client s3Client, Boolean isCrossRegionEnabled) {
         S3AccessGrantsUtils.argumentNotNull(authSchemeProvider,
                 "Expecting an Auth Scheme Provider to be specified while configuring S3Clients!");
+        S3AccessGrantsUtils.argumentNotNull(s3Client, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "S3 Client", "Plugin"));
         this.authSchemeProvider = authSchemeProvider;
+        this.s3Client = s3Client;
+        this.isCrossRegionAccessEnabled = isCrossRegionEnabled == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING : isCrossRegionEnabled;
+        this.permissionMapper = new S3AccessGrantsStaticOperationToPermissionMapper();
     }
 
     /**
@@ -54,16 +78,33 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
                 "An internal exception has occurred. Valid auth scheme params were not passed to the Auth Scheme Provider. Please contact the S3 Access Grants plugin team!");
 
         List<AuthSchemeOption> availableAuthSchemes = authSchemeProvider.resolveAuthScheme(authSchemeParams);
-        String S3Prefix = "s3://"+authSchemeParams.bucket()+"/"+getKeyIfExists(authSchemeParams);
 
-        return availableAuthSchemes.stream()
-                .map(authScheme -> authScheme.toBuilder().putIdentityProperty(OPERATION_PROPERTY,
-                                authSchemeParams.operation())
-                        .putIdentityProperty(PREFIX_PROPERTY,
-                                S3Prefix)
-                        .build()
-                )
-                .collect(Collectors.toList());
+        try {
+            final Permission permission = permissionMapper.getPermission(authSchemeParams.operation());
+
+            S3AccessGrantsUtils.argumentNotNull(authSchemeParams.bucket(), "Please specify a valid bucket name for the operation!");
+
+            final Region destinationRegion = getBucketLocation(authSchemeParams.bucket());
+
+            logger.debug(() -> "Access Grants requests will be sent to the region "+destinationRegion);
+            logger.debug(() -> "operation : " + authSchemeParams.operation());
+
+            String S3Prefix = "s3://"+authSchemeParams.bucket()+"/"+getKeyIfExists(authSchemeParams);
+
+            return availableAuthSchemes.stream()
+                    .map(authScheme -> authScheme.toBuilder()
+                            .putIdentityProperty(PREFIX_PROPERTY,
+                                    S3Prefix)
+                            .putIdentityProperty(BUCKET_LOCATION_PROPERTY, destinationRegion)
+                            .putIdentityProperty(PERMISSION_PROPERTY, permission)
+                            .build()
+                    )
+                    .collect(Collectors.toList());
+        } catch (SdkServiceException e) {
+            return availableAuthSchemes.stream()
+                    .map(authScheme -> authScheme.toBuilder().putIdentityProperty(AUTH_EXCEPTIONS_PROPERTY, e).build())
+                    .collect(Collectors.toList());
+        }
     }
 
     private String getKeyIfExists(S3AuthSchemeParams authSchemeParams) {
@@ -79,4 +120,21 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
         return keyDoesNotExists ? "*" : validKey;
 
     }
+
+    /**
+     * Fetch the location where the bucket is created.
+     * This is to ensure that the Access Grants requests are made to the correct region.
+     * @param bucketName bucket name in the users request
+     * @return Region where the S3 bucket exists
+     */
+    private Region getBucketLocation(String bucketName) {
+        if(isCrossRegionAccessEnabled) {
+            HeadBucketRequest bucketLocationRequest = HeadBucketRequest.builder().bucket(bucketName).build();
+            HeadBucketResponse headBucketResponse = s3Client.headBucket(bucketLocationRequest);
+            return Region.of(headBucketResponse.bucketRegion());
+        }
+        S3AccessGrantsUtils.argumentNotNull(s3Client.serviceClientConfiguration().region(), "Expecting a region to be configured on the S3Clients!");
+        return s3Client.serviceClientConfiguration().region();
+    }
+
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -131,6 +131,7 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
     private Region getBucketLocation(String bucketName) {
       try {
           if (isCrossRegionAccessEnabled) {
+              logger.info(() -> "making a call to determine the bucket region!");
               HeadBucketRequest bucketLocationRequest = HeadBucketRequest.builder().bucket(bucketName).build();
               HeadBucketResponse headBucketResponse = s3Client.headBucket(bucketLocationRequest);
               return Region.of(headBucketResponse.bucketRegion());

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -58,13 +58,13 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
 
     private final S3AccessGrantsOperationToPermissionMapper permissionMapper;
 
-    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider, S3Client s3Client, Boolean isCrossRegionEnabled) {
+    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider, S3Client s3Client, Boolean isCrossRegionAccessEnabled) {
         S3AccessGrantsUtils.argumentNotNull(authSchemeProvider,
                 "Expecting an Auth Scheme Provider to be specified while configuring S3Clients!");
         S3AccessGrantsUtils.argumentNotNull(s3Client, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "S3 Client", "Plugin"));
         this.authSchemeProvider = authSchemeProvider;
         this.s3Client = s3Client;
-        this.isCrossRegionAccessEnabled = isCrossRegionEnabled == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING : isCrossRegionEnabled;
+        this.isCrossRegionAccessEnabled = isCrossRegionAccessEnabled == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING : isCrossRegionAccessEnabled;
         this.permissionMapper = new S3AccessGrantsStaticOperationToPermissionMapper();
     }
 

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -18,7 +18,6 @@ package software.amazon.awssdk.s3accessgrants.plugin;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.assertj.core.api.Assertions;
 import software.amazon.awssdk.annotations.NotNull;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.regions.Region;
@@ -30,9 +29,6 @@ import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeParams;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
-import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3control.model.Permission;
 
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
@@ -69,7 +65,7 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
         this.s3Client = s3Client;
         this.isCrossRegionAccessEnabled = isCrossRegionAccessEnabled == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING : isCrossRegionAccessEnabled;
         this.permissionMapper = new S3AccessGrantsStaticOperationToPermissionMapper();
-        this.bucketRegionCache = S3AccessGrantsCachedBucketRegionResolver.builder().build();
+        this.bucketRegionCache = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
     }
 
     /**
@@ -135,7 +131,7 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
     private Region getBucketLocation(String bucketName) {
 
         if(isCrossRegionAccessEnabled) {
-            return bucketRegionCache.resolve(bucketName, s3Client);
+            return bucketRegionCache.resolve(bucketName);
         }
 
         S3AccessGrantsUtils.argumentNotNull(s3Client.serviceClientConfiguration().region(), "Expecting a region to be configured on the S3Clients!");

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -166,7 +166,7 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
         } catch(SdkServiceException e) {
 
             if(shouldFallbackToDefaultCredentialsForThisCase(e.statusCode(), e.getCause())) {
-                return userCredentials;
+                return credentialsProvider.resolveIdentity(resolveIdentityRequest);
             }
             throw e;
         }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -16,11 +16,9 @@
 package software.amazon.awssdk.s3accessgrants.plugin;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.NotNull;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -32,16 +30,11 @@ import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.services.s3control.model.Privilege;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 import software.amazon.awssdk.services.s3control.model.Permission;
-import software.amazon.awssdk.services.s3control.model.GetDataAccessRequest;
-import software.amazon.awssdk.services.s3control.model.Credentials;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
-import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsStaticOperationToPermissionMapper;
 import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
-import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 import software.amazon.awssdk.utils.Validate;
 
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.AUTH_EXCEPTIONS_PROPERTY;
@@ -266,6 +259,7 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
      * For every request, if the caller credentials have been used previously, the accountID resolved for that credentials will be returned.
      * If a new set of credentials are being used, then a request will be forwarded to STS to fetch the caller accountID and cache it.
      * Each Identity provider is only going to cache one set of credentials/accountID at any point of time.
+     * This should be a safe considering service clients can refer to only one set of credentials for each request.
      * @return a completableFuture containing response from STS.
      * */
     String getCallerAccountID(CompletableFuture<? extends AwsCredentialsIdentity> userCredentials) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -263,6 +263,9 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
 
     /**
      * Fetches the caller accountID from the requester using STS.
+     * For every request, if the caller credentials have been used previously, the accountID resolved for that credentials will be returned.
+     * If a new set of credentials are being used, then a request will be forwarded to STS to fetch the caller accountID and cache it.
+     * Each Identity provider is only going to cache one set of credentials/accountID at any point of time.
      * @return a completableFuture containing response from STS.
      * */
     String getCallerAccountID(CompletableFuture<? extends AwsCredentialsIdentity> userCredentials) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -141,6 +141,7 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
             logger.debug(() -> " S3Prefix : " + S3Prefix);
             logger.debug(() -> " caller accountID : " + accountId);
             logger.debug(() -> " permission : " + permission);
+            logger.debug(() -> " bucket region : " + destinationRegion);
 
             return getCredentialsFromCache(userCredentials.join(), permission, S3Prefix, accountId, s3ControlAsyncClient);
         } catch(SdkServiceException e) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -81,6 +81,7 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
         }
         if(!enableCrossRegionAccess()) {
             logger.warn(() -> "cross-region access not opted in! S3 Client will not be able to communicate with buckets outside the configured region!");
+            logger.warn(() -> "Please turn-on cross region access on the plugin if you have turned on cross-region access settings on your S3 Client!");
         }
 
         S3ServiceClientConfiguration.Builder serviceClientConfiguration =

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -88,6 +88,7 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
 
         S3Client s3Client = S3Client
                 .builder()
+                .crossRegionAccessEnabled(true)
                 .credentialsProvider(serviceClientConfiguration.credentialsProvider())
                 .region(serviceClientConfiguration.region())
                 .build();

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -79,6 +79,9 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
         if(!enableFallback()) {
             logger.warn(() -> "Fallback not opted in! S3 Client will not fall back to evaluate policies if permissions are not provided through S3 Access Grants!");
         }
+        if(!enableCrossRegionAccess()) {
+            logger.warn(() -> "cross-region access not opted in! S3 Client will not be able to communicate with buckets outside the configured region!");
+        }
 
         S3ServiceClientConfiguration.Builder serviceClientConfiguration =
                 Validate.isInstanceOf(S3ServiceClientConfiguration.Builder.class,

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -19,6 +19,7 @@ import software.amazon.awssdk.annotations.NotNull;
 import software.amazon.awssdk.core.SdkPlugin;
 import software.amazon.awssdk.core.SdkServiceClientConfiguration;
 import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedCredentialsProvider;
 import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedCredentialsProviderImpl;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -28,6 +29,8 @@ import software.amazon.awssdk.services.sts.StsAsyncClient;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.utils.Validate;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.DEFAULT_PRIVILEGE_FOR_PLUGIN;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.DEFAULT_CACHE_SETTING;
@@ -97,6 +100,8 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
 
         S3AccessGrantsCachedCredentialsProvider cache = createAccessGrantsCache();
 
+        ConcurrentHashMap<Region, S3ControlAsyncClient> clientsCache = new ConcurrentHashMap<>();
+
         StsAsyncClient stsClient = StsAsyncClient.builder()
                 .credentialsProvider(serviceClientConfiguration.credentialsProvider())
                 .region(serviceClientConfiguration.region())
@@ -111,7 +116,8 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
                 s3ControlAsyncClientBuilder,
                 cache,
                 enableFallback,
-                metricPublisher
+                metricPublisher,
+                clientsCache
                 ));
 
         logger.debug(() -> "Completed configuring S3 Clients to use S3 Access Grants as a permission layer!");

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/internal/S3AccessGrantsUtils.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/internal/S3AccessGrantsUtils.java
@@ -15,7 +15,9 @@
 
 package software.amazon.awssdk.s3accessgrants.plugin.internal;
 
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3control.model.Privilege;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -28,12 +30,21 @@ public class S3AccessGrantsUtils {
     public static Logger logger = Logger.loggerFor("software.amazon.awssdk.s3accessgrants");
     public static final IdentityProperty PREFIX_PROPERTY = IdentityProperty.create(String.class, "S3Prefix");
     public static final IdentityProperty OPERATION_PROPERTY = IdentityProperty.create(String.class,"Operation");
+    public static final IdentityProperty BUCKET_LOCATION_PROPERTY = IdentityProperty.create(Region.class, "BucketLocation");
+
+    public static final IdentityProperty AUTH_EXCEPTIONS_PROPERTY = IdentityProperty.create(SdkServiceException.class, "AuthExceptions");
+
+    public static final IdentityProperty PERMISSION_PROPERTY = IdentityProperty.create(String.class, "PermissionProperty");
+
+    public static String CONTACT_TEAM_MESSAGE_TEMPLATE = "An internal exception has occurred. Valid %s was not passed to the %s. Please contact S3 access grants plugin team!";
 
     public static final Boolean DEFAULT_CACHE_SETTING = true;
 
     public static final Privilege DEFAULT_PRIVILEGE_FOR_PLUGIN = Privilege.DEFAULT;
 
     public static final Boolean DEFAULT_FALLBACK_SETTING = false;
+
+    public static final Boolean DEFAULT_CROSS_REGION_ACCESS_SETTING = false;
 
     public static void argumentNotNull(Object param, String message) {
         try{

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
@@ -2,9 +2,12 @@ package software.amazon.awssdk.s3accessgrants.cache;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.*;
 
 public class S3AccessGrantsBucketRegionResolverCreationTest {
@@ -12,9 +15,16 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
     private static int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
     private static int TEST_CACHE_EXPIRATION_DURATION = 6_0;
 
+    private static S3Client s3Client;
+
+    @BeforeClass
+    public static void setUp() {
+        s3Client = mock(S3Client.class);
+    }
+
     @Test
     public void create_bucket_region_cache_with_default_settings() {
-        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = new S3AccessGrantsCachedBucketRegionResolver();
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
         Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
         Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
     }
@@ -25,6 +35,7 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
                 .builder()
                 .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
                 .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .s3Client(s3Client)
                 .build();
         Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
         Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
@@ -32,7 +43,7 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
 
     @Test
     public void create_bucket_region_cache_with_builder_default_settings() {
-        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().build();
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
         Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
         Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
     }
@@ -44,12 +55,14 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
                 .builder()
                 .maxCacheSize(MAX_BUCKET_REGION_CACHE_SIZE+1)
                 .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .s3Client(s3Client)
                 .build()).isInstanceOf(IllegalArgumentException.class);
 
         Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
                 .builder()
                 .maxCacheSize(0)
                 .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .s3Client(s3Client)
                 .build()).isInstanceOf(IllegalArgumentException.class);
 
     }
@@ -61,12 +74,14 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
                 .builder()
                 .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
                 .expireCacheAfterWriteSeconds(MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS+10)
+                .s3Client(s3Client)
                 .build()).isInstanceOf(IllegalArgumentException.class);
 
         Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
                 .builder()
                 .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
                 .expireCacheAfterWriteSeconds(0)
+                .s3Client(s3Client)
                 .build()).isInstanceOf(IllegalArgumentException.class);
 
     }
@@ -74,16 +89,27 @@ public class S3AccessGrantsBucketRegionResolverCreationTest {
     @Test
     public void copy_Resolver() {
 
-        S3AccessGrantsCachedAccountIdResolver cachedBucketRegionResolver = S3AccessGrantsCachedAccountIdResolver
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
                 .builder()
                 .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
                 .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .s3Client(s3Client)
                 .build();
-        S3AccessGrantsCachedAccountIdResolver copy = cachedBucketRegionResolver.toBuilder().build();
+        S3AccessGrantsCachedBucketRegionResolver copy = cachedBucketRegionResolver.toBuilder().build();
 
         Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, copy.maxCacheSize());
         Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, copy.expireCacheAfterWriteSeconds());
 
+    }
+
+    @Test
+    public void test_invalidS3Client() {
+       Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .s3Client(null)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .build()).isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
@@ -1,0 +1,91 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.*;
+
+public class S3AccessGrantsBucketRegionResolverCreationTest {
+
+    private static int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
+    private static int TEST_CACHE_EXPIRATION_DURATION = 6_0;
+
+    @Test
+    public void create_bucket_region_cache_with_default_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = new S3AccessGrantsCachedBucketRegionResolver();
+        Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_custom_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .build();
+        Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_builder_default_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().build();
+        Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_invalid_max_cache_size() {
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(MAX_BUCKET_REGION_CACHE_SIZE+1)
+                .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(0)
+                .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_invalid_expiration_duration() {
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS+10)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(0)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void copy_Resolver() {
+
+        S3AccessGrantsCachedAccountIdResolver cachedBucketRegionResolver = S3AccessGrantsCachedAccountIdResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .build();
+        S3AccessGrantsCachedAccountIdResolver copy = cachedBucketRegionResolver.toBuilder().build();
+
+        Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, copy.maxCacheSize());
+        Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, copy.expireCacheAfterWriteSeconds());
+
+    }
+
+}
+
+

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
@@ -6,14 +6,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
-import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.*;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
 
 public class S3AccessGrantsBucketRegionResolverCreationTest {
 
-    private static int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
-    private static int TEST_CACHE_EXPIRATION_DURATION = 6_0;
+    private static final int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
+    private static final int TEST_CACHE_EXPIRATION_DURATION = 6_0;
 
     private static S3Client s3Client;
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -1,0 +1,128 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class S3AccessGrantsBucketRegionResolverTest {
+
+    private S3Client s3Client;
+    private S3AccessGrantsCachedBucketRegionResolver s3AccessGrantsCachedBucketRegionResolver;
+    private String TEST_BUCKET_NAME;
+
+    @Before
+    public void setUp() {
+        s3Client = mock(S3Client.class);
+        TEST_BUCKET_NAME = "test-bucket";
+        s3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().build();
+        HeadBucketResponse headBucketResponse = HeadBucketResponse.builder().bucketRegion(Region.US_EAST_1.toString()).build();
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(headBucketResponse);
+    }
+
+    @Test
+    public void call_resolve_with_invalid_s3Client() {
+        S3Client invalidS3Client = null;
+        Assertions.assertThatThrownBy(() -> s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, invalidS3Client))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void call_resolve_should_cache_the_bucket_region() {
+        Assert.assertEquals(s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client), Region.US_EAST_1);
+        // initial request should be made to the service
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Assert.assertEquals(s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client), Region.US_EAST_1);
+        // No call should be made to the service as the region is already cached
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+    }
+
+    @Test
+    public void call_resolve_should_not_cache_the_bucket_region() {
+        S3Client localS3Client = mock(S3Client.class);
+        HeadBucketResponse headBucketResponse = HeadBucketResponse.builder().bucketRegion(null).build();
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(headBucketResponse);
+        Assertions.assertThatThrownBy(() -> s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, localS3Client)).isInstanceOf(SdkServiceException.class);
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Assertions.assertThatThrownBy(() -> s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, localS3Client)).isInstanceOf(SdkServiceException.class);
+        verify(localS3Client, times(2)).headBucket(any(HeadBucketRequest.class));
+    }
+
+    @Test
+    public void verify_bucket_region_cache_expiration() throws InterruptedException {
+
+        S3AccessGrantsCachedBucketRegionResolver localCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .expireCacheAfterWriteSeconds(1)
+                .build();
+
+        Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client));
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Thread.sleep(1000);
+        // should evict the entry after 1 sec and the subsequent request should call the service
+        Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client));
+        verify(s3Client, times(2)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_with_non_existent_bucket() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(S3Exception.builder().message("Bucket does not exist").statusCode(404).build());
+        Assertions.assertThatThrownBy(() ->  s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, localS3Client)).isInstanceOf(S3Exception.class);
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_resolve_returns_redirect() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        AwsServiceException s3Exception = mock(S3Exception.class);
+        List<String> regionList = new ArrayList<>();
+        regionList.add(Region.US_EAST_1.toString());
+        SdkHttpResponse sdkHttpResponse = SdkHttpResponse.builder().putHeader("x-amz-bucket-region", regionList).build();
+        AwsErrorDetails awsErrorDetails = AwsErrorDetails.builder().sdkHttpResponse(sdkHttpResponse).build();
+        when(s3Exception.statusCode()).thenReturn(301);
+        when(s3Exception.awsErrorDetails()).thenReturn(awsErrorDetails);
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception);
+        Assert.assertEquals(Region.US_EAST_1, s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, localS3Client));
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_resolve_returns_redirect_with_null_region() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        AwsServiceException s3Exception = mock(S3Exception.class);
+        List<String> regionList = new ArrayList<>();
+        regionList.add(null);
+        SdkHttpResponse sdkHttpResponse = SdkHttpResponse.builder().putHeader("x-amz-bucket-region", regionList).build();
+        AwsErrorDetails awsErrorDetails = AwsErrorDetails.builder().sdkHttpResponse(sdkHttpResponse).build();
+        when(s3Exception.statusCode()).thenReturn(301);
+        when(s3Exception.awsErrorDetails()).thenReturn(awsErrorDetails);
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception);
+        Assertions.assertThatThrownBy(() -> s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, localS3Client))
+                .isInstanceOf(SdkServiceException.class);
+
+    }
+
+}

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -74,8 +74,8 @@ public class S3AccessGrantsBucketRegionResolverTest {
 
         Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client));
         verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
-        Thread.sleep(1000);
-        // should evict the entry after 1 sec and the subsequent request should call the service
+        Thread.sleep(2000);
+        // should evict the entry and the subsequent request should call the service
         Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME, s3Client));
         verify(s3Client, times(2)).headBucket(any(HeadBucketRequest.class));
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.s3accessgrants.cache;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -19,7 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 public class S3AccessGrantsBucketRegionResolverTest {
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCacheTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCacheTest.java
@@ -239,7 +239,6 @@ public class S3AccessGrantsCacheTest {
     @Test
     public void accessGrantsCache_testNullS3ControlAsyncClientException() {
         assertThatNoException().isThrownBy(() -> S3AccessGrantsCache.builder()
-                        .s3ControlAsyncClient(null)
                         .maxCacheSize(DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE).build());
 
     }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCacheTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCacheTest.java
@@ -15,7 +15,7 @@
 
 package software.amazon.awssdk.s3accessgrants.cache;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.time.Duration;
@@ -66,11 +66,9 @@ public class S3AccessGrantsCacheTest {
         mockResolver = Mockito.mock(S3AccessGrantsCachedAccountIdResolver.class);
         s3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
         cache = S3AccessGrantsCache.builder()
-                                   .s3ControlAsyncClient(s3ControlAsyncClient)
                                    .cacheExpirationTimePercentage(60)
                                    .maxCacheSize(DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE).build();
         cacheWithMockedAccountIdResolver = S3AccessGrantsCache.builder()
-                                                              .s3ControlAsyncClient(s3ControlAsyncClient)
                                                               .cacheExpirationTimePercentage(60)
                                                               .s3AccessGrantsCachedAccountIdResolver(mockResolver)
                                                               .maxCacheSize(DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE).buildWithAccountIdResolver();
@@ -115,8 +113,8 @@ public class S3AccessGrantsCacheTest {
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket2/foo/bar").build();
         // When
-        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
-        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
+        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         assertThat(cacheValue2).isEqualTo(cacheValue1);
     }
@@ -139,8 +137,8 @@ public class S3AccessGrantsCacheTest {
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket2/foo/bar/logs").build();
         // When
-        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
-        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
+        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         assertThat(cacheValue2).isEqualTo(cacheValue1);
     }
@@ -160,8 +158,8 @@ public class S3AccessGrantsCacheTest {
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket2/foo/bar/logs").build();
         // When
-        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
-        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
+        AwsCredentialsIdentity cacheValue2 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         assertThat(cacheValue2).isEqualTo(cacheValue1);
     }
@@ -185,12 +183,12 @@ public class S3AccessGrantsCacheTest {
                                 .s3Prefix("s3://bucket2/foo/bar").build();
 
         assertThat(S3_ACCESS_GRANTS_CREDENTIALS).isEqualTo(cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT,
-                                                                                accessDeniedCache).join());
+                                                                                accessDeniedCache, s3ControlAsyncClient).join());
         // When
         Thread.sleep(3000);
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponseSetUp("s3://bucket2/foo/bar"));
-        cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         verify(s3ControlAsyncClient, atLeastOnce()).getDataAccess(any(GetDataAccessRequest.class));
     }
@@ -205,10 +203,10 @@ public class S3AccessGrantsCacheTest {
                                .s3Prefix("s3://bucket/foo/bar").build();
         CompletableFuture<GetDataAccessResponse> getDataAccessResponse = getDataAccessResponseSetUp("s3://bucket2/foo/bar");
 
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
         // When
-        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         verify(s3ControlAsyncClient, atLeastOnce()).getDataAccess(any(GetDataAccessRequest.class));
     }
@@ -229,10 +227,10 @@ public class S3AccessGrantsCacheTest {
 
         CompletableFuture<GetDataAccessResponse> getDataAccessResponse = getDataAccessResponseSetUp("s3://bucket2/foo/bar");
 
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
         // When
-        cacheWithMockedAccountIdResolver.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         verify(s3ControlAsyncClient, atLeastOnce()).getDataAccess(any(GetDataAccessRequest.class));
 
@@ -240,10 +238,9 @@ public class S3AccessGrantsCacheTest {
 
     @Test
     public void accessGrantsCache_testNullS3ControlAsyncClientException() {
-        assertThatThrownBy(() -> S3AccessGrantsCache.builder()
-                                                    .s3ControlAsyncClient(null)
-                                                    .maxCacheSize(DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE).build())
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThatNoException().isThrownBy(() -> S3AccessGrantsCache.builder()
+                        .s3ControlAsyncClient(null)
+                        .maxCacheSize(DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE).build());
 
     }
 
@@ -257,12 +254,12 @@ public class S3AccessGrantsCacheTest {
 
         S3ControlException s3ControlException = Mockito.mock(S3ControlException.class);
 
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenThrow(s3ControlException);
         when(s3ControlException.statusCode()).thenReturn(403);
         // When
         try {
-            cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+            cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         }catch (S3ControlException e){}
         // Then
         assertThat(accessDeniedCache.getValueFromCache(key1)).isInstanceOf(S3ControlException.class);
@@ -297,18 +294,19 @@ public class S3AccessGrantsCacheTest {
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket/foo/bar/text.txt").build();
 
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
-        cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key1, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache, s3ControlAsyncClient).join();
         // When
         CacheKey key2 = CacheKey.builder()
                                 .credentials(AWS_BASIC_CREDENTIALS)
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket/foo/log/text.txt").build();
-        cacheWithMockedAccountIdResolver.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         verify(s3ControlAsyncClient, times(1)).getDataAccess(any(GetDataAccessRequest.class));
     }
+
     @Test
     public void accessGrantsCache_testGrantWithPrefix() {
         // Given
@@ -322,7 +320,7 @@ public class S3AccessGrantsCacheTest {
                                 .s3Prefix("s3://bucket2/foo/text.txt").build();
         cache.putValueInCache(key1, CompletableFuture.supplyAsync(() -> S3_ACCESS_GRANTS_CREDENTIALS), 2);
         // When
-        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache).join();
+        AwsCredentialsIdentity cacheValue1 = cache.getCredentials(key2, TEST_S3_ACCESSGRANTS_ACCOUNT, accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         assertThat(cacheValue1).isEqualTo(S3_ACCESS_GRANTS_CREDENTIALS);
         verify(s3ControlAsyncClient, times(0)).getDataAccess(any(GetDataAccessRequest.class));
@@ -346,10 +344,10 @@ public class S3AccessGrantsCacheTest {
                                 .permission(Permission.READ)
                                 .s3Prefix("s3://bucket/foo/bar/text.txt").build();
         // When
-        when(mockResolver.resolve(any(String.class), any(String.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
+        when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(s3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
-        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache).join();
-        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache, s3ControlAsyncClient).join();
+        cacheWithMockedAccountIdResolver.getCredentials(key, TEST_S3_ACCESSGRANTS_ACCOUNT,accessDeniedCache, s3ControlAsyncClient).join();
         // Then
         verify(s3ControlAsyncClient, times(2)).getDataAccess(any(GetDataAccessRequest.class));
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.s3accessgrants.cache;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
@@ -34,27 +35,18 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
     }
 
     @Test
-    public void create_DefaultResolver_without_S3ControlAsyncClient_via_Constructor() {
-        // Given
-        S3ControlAsyncClient = null;
-        // Then
-        assertThatIllegalArgumentException().isThrownBy(() -> new S3AccessGrantsCachedAccountIdResolver(S3ControlAsyncClient));
-    }
-
-    @Test
     public void create_DefaultResolver_via_Constructor() {
         // When
-        S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver(S3ControlAsyncClient);
+        S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS);
     }
 
     @Test
     public void create_Resolver_via_Builder() {
-        assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
+        assertThatNoException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
             .build());
     }
@@ -64,7 +56,7 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Given
         S3ControlAsyncClient = null;
         //Then
-        assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
+        assertThatNoException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
             .S3ControlAsyncClient(S3ControlAsyncClient)
             .build());
@@ -75,11 +67,9 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS);
     }
@@ -92,13 +82,11 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(customMaxCacheSize);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(customExpireCacheAfterWriteSeconds);
     }
@@ -110,7 +98,6 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Then
         assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .build());
     }
@@ -122,7 +109,6 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Then
         assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build());
     }
@@ -135,14 +121,12 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build();
         S3AccessGrantsCachedAccountIdResolver copy = resolver.toBuilder().build();
         // Then
         assertThat(copy).isNotNull();
-        assertThat(copy.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(copy.maxCacheSize()).isEqualTo(customMaxCacheSize);
         assertThat(copy.expireCacheAfterWriteSeconds()).isEqualTo(customExpireCacheAfterWriteSeconds);
     }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
@@ -58,7 +58,6 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         //Then
         assertThatNoException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build());
     }
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverTest.java
@@ -47,7 +47,6 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         S3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
         resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build();
     }
 
@@ -64,7 +63,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class)))
             .thenReturn(response);
         // When
-        String accountId = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
+        String accountId = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
         // Then
         assertThat(accountId).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         verify(S3ControlAsyncClient, times(1)).getAccessGrantsInstanceForPrefix(requestArgumentCaptor.capture());
@@ -84,8 +83,8 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                                                         .accessGrantsInstanceArn(TEST_S3_ACCESSGRANTS_INSTANCE_ARN).build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // When attempting to resolve same prefix back to back
-        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
-        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
+        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
+        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
         // Then
         assertThat(accountId1).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         assertThat(accountId2).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
@@ -105,8 +104,8 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                     .accessGrantsInstanceArn(TEST_S3_ACCESSGRANTS_INSTANCE_ARN).build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // When attempting to resolve same prefix back to back
-        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
-        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX_2);
+        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
+        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX_2, S3ControlAsyncClient);
         // Then
         assertThat(accountId1).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         assertThat(accountId2).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
@@ -120,7 +119,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class)))
             .thenThrow(S3ControlException.builder().build());
         // Then
-        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX)).isInstanceOf(S3ControlException.class);
+        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient)).isInstanceOf(S3ControlException.class);
 
     }
 
@@ -133,7 +132,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                     .accessGrantsInstanceArn("").build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // Then
-        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX)).isInstanceOf(S3ControlException.class);
+        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient)).isInstanceOf(S3ControlException.class);
     }
 
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImplTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImplTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.services.s3control.model.Credentials;
 import software.amazon.awssdk.services.s3control.model.GetDataAccessRequest;
 import software.amazon.awssdk.services.s3control.model.GetDataAccessResponse;
@@ -45,7 +46,7 @@ import software.amazon.awssdk.services.s3control.model.Permission;
 public class S3AccessGrantsCachedCredentialsProviderImplTest {
     S3AccessGrantsCachedCredentialsProviderImpl cache;
     S3AccessGrantsCachedCredentialsProviderImpl cacheWithMockedAccountIdResolver;
-    static S3ControlAsyncClient S3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
+    static S3ControlAsyncClient S3ControlAsyncClient;
     static S3AccessGrantsCachedAccountIdResolver mockResolver = Mockito.mock(S3AccessGrantsCachedAccountIdResolver.class);
     static Credentials credentials;
 
@@ -78,6 +79,7 @@ public class S3AccessGrantsCachedCredentialsProviderImplTest {
     @Test
     public void cacheImpl_cacheHit() {
         // Given
+        S3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
         CompletableFuture<GetDataAccessResponse> getDataAccessResponse = getDataAccessResponseSetUp("s3://bucket2/foo/*");
         when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(S3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
@@ -99,6 +101,7 @@ public class S3AccessGrantsCachedCredentialsProviderImplTest {
     @Test
     public void cacheImpl_cacheMiss() {
         // Given
+        S3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
         CompletableFuture<GetDataAccessResponse> getDataAccessResponse = getDataAccessResponseSetUp("s3://bucket2/foo/bar");
         when(mockResolver.resolve(any(String.class), any(String.class), any(S3ControlAsyncClient.class))).thenReturn(TEST_S3_ACCESSGRANTS_ACCOUNT);
         when(S3ControlAsyncClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProviderTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProviderTests.java
@@ -20,17 +20,25 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import java.util.List;
 import java.util.ArrayList;
+
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeParams;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3control.model.Permission;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static org.mockito.Mockito.any;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.*;
 
 
 public class S3AccessGrantsAuthSchemeProviderTests {
@@ -42,30 +50,48 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     private static List<AuthSchemeOption> authSchemeResolverResult;
     private static final String SIGNING_SCHEME = "aws.auth#sigv4";
 
+    private static final S3Client s3client = mock(S3Client.class);
+
+    private static final Boolean DefaultCrossRegionAccess = false;
+
     @BeforeClass
     public static void setUp() {
         authSchemeResolverResult = new ArrayList<>();
         authSchemeResolverResult.add(AuthSchemeOption.builder().schemeId(SIGNING_SCHEME).build());
+        when(s3client.serviceClientConfiguration()).thenReturn(S3ServiceClientConfiguration.builder().region(Region.US_EAST_2).build());
+        when(s3client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().bucketRegion(Region.US_EAST_1.toString()).build());
     }
 
     @Test
     public void create_authSchemeProvider_with_no_DefaultAuthProvider() {
 
-       Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(null)).isInstanceOf(IllegalArgumentException.class);
+       Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(null, s3client, DefaultCrossRegionAccess)).isInstanceOf(IllegalArgumentException.class);
 
+    }
+
+    @Test
+    public void create_authSchemeProvider_with_no_s3client() {
+        S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
+        Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, null, DefaultCrossRegionAccess)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void create_authSchemeProvider_with_no_cross_region_access_setting() {
+        S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
+        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, null));
     }
 
     @Test
     public void create_authSchemeProvider_with_valid_DefaultAuthProvider() {
         S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
 
-        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider));
+        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess));
     }
 
     @Test
     public void call_authSchemeProvider_with_null_params() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = null;
 
         Assertions.assertThatThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
@@ -73,20 +99,76 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     }
 
     @Test
-    public void call_authSchemeProvider_with_valid_params_valid_bucket() {
+    public void call_authSchemeProvider_without_valid_region() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3Client mockS3Client = mock(S3Client.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, mockS3Client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
-        Assertions.assertThatNoException().isThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams));
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        when(mockS3Client.serviceClientConfiguration()).thenReturn(S3ServiceClientConfiguration.builder().build());
+        Assertions.assertThatThrownBy(() -> accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_valid_bucket_cross_region_access_disabled() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_valid_bucket_cross_region_access_enabled() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_1);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_invalid_bucket_operation_supported() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(null);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        Assertions.assertThatThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
         verify(authSchemeProvider, times(1)).resolveAuthScheme(authSchemeParams);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_invalid_bucket_operation_not_supported() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(null);
+        when(authSchemeParams.operation()).thenReturn("ListBucket");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        SdkServiceException e = (SdkServiceException) accessGrantsAuthSchemeResult.get(0).identityProperty(AUTH_EXCEPTIONS_PROPERTY);
+        Assertions.assertThat(e.getCause()).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_null_key() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).key(null).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -94,16 +176,18 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/*");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(AUTH_EXCEPTIONS_PROPERTY)).isNull();
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_invokes_default_authSchemeProvider() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
 
         Assertions.assertThatNoException().isThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams));
         verify(authSchemeProvider, times(1)).resolveAuthScheme(authSchemeParams);
@@ -112,10 +196,11 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     @Test
     public void call_authSchemeProvider_with_valid_params_invokes_default_authSchemeProvider_returning_valid_result() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
 
         Assertions.assertThat(accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams).get(0).schemeId()).isEqualTo(SIGNING_SCHEME);
@@ -125,7 +210,7 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     @Test
     public void call_authSchemeProvider_with_valid_params_captures_all_params_on_auth_scheme() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).key(KEY).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -133,13 +218,14 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/test-key");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PERMISSION_PROPERTY)).isEqualTo(Permission.READ);
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_captures_all_params_with_prefix_as_object_key_on_auth_scheme() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).prefix(KEY).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -147,7 +233,8 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/test-key");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PERMISSION_PROPERTY)).isEqualTo(Permission.READ);
     }
 
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProviderTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProviderTests.java
@@ -1,18 +1,18 @@
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+///*
+// * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License").
+// * You may not use this file except in compliance with the License.
+// * A copy of the License is located at
+// *
+// *  http://aws.amazon.com/apache2.0
+// *
+// * or in the "license" file accompanying this file. This file is distributed
+// * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// * express or implied. See the License for the specific language governing
+// * permissions and limitations under the License.
+// */
+//
 package software.amazon.awssdk.s3accessgrants.plugin;
 
 import java.nio.file.AccessDeniedException;
@@ -35,20 +35,11 @@ import software.amazon.awssdk.metrics.publishers.cloudwatch.CloudWatchMetricPubl
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedCredentialsProvider;
 import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedCredentialsProviderImpl;
-import software.amazon.awssdk.services.s3control.model.Privilege;
-import software.amazon.awssdk.services.s3control.model.GetDataAccessResponse;
-import software.amazon.awssdk.services.s3control.model.GetDataAccessRequest;
-import software.amazon.awssdk.services.s3control.model.Credentials;
-import software.amazon.awssdk.services.s3control.model.S3ControlException;
-import software.amazon.awssdk.services.s3control.model.GetAccessGrantsInstanceForPrefixResponse;
-import software.amazon.awssdk.services.s3control.model.GetAccessGrantsInstanceForPrefixRequest;
-import software.amazon.awssdk.services.s3control.model.InvalidRequestException;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
+import software.amazon.awssdk.services.s3control.model.*;
 
 
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
-
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
 
 import org.junit.BeforeClass;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
@@ -62,6 +53,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.*;
 
 public class S3AccessGrantsIdentityProviderTests {
 
@@ -85,6 +77,8 @@ public class S3AccessGrantsIdentityProviderTests {
     private static final String TEST_ACCOUNT = "12345028312";
     private static DefaultCredentialsProvider credentialsProvider;
 
+    private static S3ControlAsyncClientBuilder s3ControlAsyncClientBuilder;
+
     private static S3ControlAsyncClient s3ControlClient;
 
     private static S3AccessGrantsCachedCredentialsProvider cache;
@@ -99,6 +93,7 @@ public class S3AccessGrantsIdentityProviderTests {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        s3ControlAsyncClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         s3ControlClient = mock(S3ControlAsyncClient.class);
         cache = mock(S3AccessGrantsCachedCredentialsProvider.class);
         credentialsProvider = DefaultCredentialsProvider.create();
@@ -125,9 +120,12 @@ public class S3AccessGrantsIdentityProviderTests {
         resolveIdentityRequest = mock(ResolveIdentityRequest.class);
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket/");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn("GetObject");
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(s3ControlAsyncClientBuilder.region(Region.US_EAST_2)).thenReturn(s3ControlAsyncClientBuilder);
+        when(s3ControlAsyncClientBuilder.region(Region.US_EAST_2).build()).thenReturn(s3ControlClient);
         when(s3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
-        when(cache.getDataAccess(any(), any(), any(), any())).thenReturn(cacheResponse);
+        when(cache.getDataAccess(any(), any(), any(), any(), any())).thenReturn(cacheResponse);
         when(stsAsyncClient.getCallerIdentity()).thenReturn(callerIdentityResponse);
         when(cache.getAccessGrantsMetrics()).thenReturn(metricsCollector);
         when(metricsCollector.collect()).thenReturn(mock(MetricCollection.class));
@@ -140,17 +138,12 @@ public class S3AccessGrantsIdentityProviderTests {
 
     @Test
     public void create_identity_provider_without_default_identity_provider() {
-        Assertions.assertThatThrownBy(() -> new S3AccessGrantsIdentityProvider(null, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void create_identity_provider_without_valid_region() {
-        Assertions.assertThatThrownBy(() -> new S3AccessGrantsIdentityProvider(credentialsProvider, null, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher)).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> new S3AccessGrantsIdentityProvider(null, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void call_identity_type_returns_valid_result() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThat(accessGrantsIdentityProvider.identityType()).isEqualTo(AwsCredentialsIdentity.class);
     }
 
@@ -161,7 +154,7 @@ public class S3AccessGrantsIdentityProviderTests {
                 GetCallerIdentityResponse.builder()
                         .account(TEST_ACCOUNT)
                         .build()));
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, localAsyncStsClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, localAsyncStsClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         ResolveIdentityRequest resolveIdentityRequest = null;
         Assertions.assertThatThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest)).isInstanceOf(IllegalArgumentException.class);
         verify(localAsyncStsClient, atLeast(1)).getCallerIdentity();
@@ -169,35 +162,35 @@ public class S3AccessGrantsIdentityProviderTests {
 
     @Test
     public void call_identity_provider_with_invalid_sts_client() {
-          Assertions.assertThatThrownBy(() -> new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, null, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher));
+          Assertions.assertThatThrownBy(() -> new S3AccessGrantsIdentityProvider(credentialsProvider, null, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher));
     }
 
     @Test
     public void call_identity_provider_with_invalid_privilege() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, null, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, null, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThatThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void call_identity_provider_with_no_metrics_publisher() {
-        new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, null);
+        new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, null);
     }
 
     @Test
     public void call_identity_provider_get_account_id() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, null, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, null, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThat(accessGrantsIdentityProvider.getCallerAccountID().join().account()).isEqualTo(TEST_ACCOUNT);
     }
 
     @Test
     public void call_identity_provider_with_invalid_cache_enabled_setting() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, null, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, null, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThatThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void call_should_fallback_with_response_codes_fallback_turned_off() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(404, mock(UnsupportedOperationException.class))).isTrue();
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(404, mock(Exception.class))).isFalse();
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(403, mock(AccessDeniedException.class))).isFalse();
@@ -205,7 +198,7 @@ public class S3AccessGrantsIdentityProviderTests {
 
     @Test
     public void call_should_fallback_with_response_codes_fallback_turned_on() {
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, !TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, !TEST_FALLBACK_ENABLED, metricsPublisher);
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(404, mock(UnsupportedOperationException.class))).isTrue();
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(404, mock(Exception.class))).isTrue();
         Assertions.assertThat(accessGrantsIdentityProvider.shouldFallbackToDefaultCredentialsForThisCase(403, mock(AccessDeniedException.class))).isTrue();
@@ -224,12 +217,12 @@ public class S3AccessGrantsIdentityProviderTests {
                 .build();
         CompletableFuture<AwsCredentialsIdentity> cacheResponse  = CompletableFuture.supplyAsync(() -> credentials);
 
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
 
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> null));
         when(testCache.getAccessGrantsMetrics()).thenReturn(testMetricCollector);
         when(testMetricCollector.collect()).thenReturn(mock(MetricCollection.class));
-        when(testCache.getDataAccess(any(), any(), any(), any())).thenReturn(cacheResponse);
+        when(testCache.getDataAccess(any(), any(), any(), any(), any())).thenReturn(cacheResponse);
 
         Assertions.assertThatNoException().isThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest));
         verify(credentialsProvider, times(1)).resolveIdentity(resolveIdentityRequest);
@@ -239,7 +232,7 @@ public class S3AccessGrantsIdentityProviderTests {
     @Test
     public void call_resolve_identity_with_invalid_request_params_s3Prefix() {
 
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         ResolveIdentityRequest localResolveIdentityRequest = mock(ResolveIdentityRequest.class);
 
         when(localResolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn(null);
@@ -254,7 +247,7 @@ public class S3AccessGrantsIdentityProviderTests {
     @Test
     public void call_resolve_identity_with_invalid_request_params_operation() {
 
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         ResolveIdentityRequest localResolveIdentityRequest = mock(ResolveIdentityRequest.class);
 
         when(localResolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://");
@@ -264,62 +257,22 @@ public class S3AccessGrantsIdentityProviderTests {
     }
 
     @Test
-    public void call_resolve_identity_with_invalid_request_params_bucket_in_prefix() {
-
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
-        Assertions.assertThatThrownBy(() -> accessGrantsIdentityProvider.verifyIfValidBucket("s3://null/*"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void call_get_data_access_with_invalid_response_without_cache() {
-        IdentityProvider credentialsProvider = mock(IdentityProvider.class);
-        S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_DISABLED, localS3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
-        ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
-        CompletableFuture<GetDataAccessResponse> getDataAccessResponse = CompletableFuture.supplyAsync(() -> GetDataAccessResponse.builder().build());
-
-        when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
-        when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build()));
-
-        Assertions.assertThatThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join())
-                .isInstanceOf(CompletionException.class).getCause()
-                .isInstanceOf(NullPointerException.class);
-
-    }
-
-    @Test
-    public void call_get_data_access_with_access_denied_response_without_cache() {
-        IdentityProvider credentialsProvider = mock(IdentityProvider.class);
-        S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_DISABLED, localS3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
-        ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
-
-        when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> GetDataAccessResponse.builder().build()).whenComplete((r,e) -> { throw S3ControlException.builder().statusCode(403).build(); }));
-        when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build()));
-
-        Throwable exc = Assertions.catchThrowableOfType(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join(), CompletionException.class);
-        Assertions.assertThat(exc.getCause()).isInstanceOf(S3ControlException.class);
-        Assertions.assertThat(((S3ControlException) exc.getCause()).statusCode()).isEqualTo(403);
-    }
-
-    @Test
     public void call_get_data_access_with_access_denied_response_with_cache() throws Exception {
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
+        S3ControlAsyncClientBuilder localS3ControlClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
         S3AccessGrantsCachedCredentialsProvider testCache = mock(S3AccessGrantsCachedCredentialsProvider.class);
         MetricPublisher testMetricPublisher = mock(MetricPublisher.class);
         MetricCollector testMetricCollector = mock(MetricCollector.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClient, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClientBuilder, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(testCache.getDataAccess(any(), any(), any(), any())).thenThrow(S3ControlException.builder().statusCode(403).message("Access denied for the user").build());
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2)).thenReturn(localS3ControlClientBuilder);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2).build()).thenReturn(localS3ControlClient);
+        when(testCache.getDataAccess(any(), any(), any(), any(), any())).thenThrow(S3ControlException.builder().statusCode(403).message("Access denied for the user").build());
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build()));
         when(testCache.getAccessGrantsMetrics()).thenReturn(testMetricCollector);
         when(testMetricCollector.collect()).thenReturn(mock(MetricCollection.class));
@@ -333,16 +286,20 @@ public class S3AccessGrantsIdentityProviderTests {
     @Test
     public void call_get_data_access_with_exceptions_from_cache() throws Exception {
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
+        S3ControlAsyncClientBuilder localS3ControlClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
         S3AccessGrantsCachedCredentialsProvider testCache = mock(S3AccessGrantsCachedCredentialsProvider.class);
         MetricPublisher testMetricPublisher = mock(MetricPublisher.class);
         MetricCollector testMetricCollector = mock(MetricCollector.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClient, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClientBuilder, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(testCache.getDataAccess(any(), any(), any(), any())).thenThrow(NullPointerException.class);
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2)).thenReturn(localS3ControlClientBuilder);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2).build()).thenReturn(localS3ControlClient);
+        when(testCache.getDataAccess(any(), any(), any(), any(), any())).thenThrow(NullPointerException.class);
         when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> GetDataAccessResponse.builder().build()).whenComplete((r,e) -> { throw S3ControlException.builder().statusCode(403).build(); }));
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build()));
         when(testCache.getAccessGrantsMetrics()).thenReturn(testMetricCollector);
@@ -355,43 +312,27 @@ public class S3AccessGrantsIdentityProviderTests {
         verify(testMetricPublisher, times(1)).publish(any());
     }
 
-    @Test
-    public void call_get_data_access_with_success_response_without_cache() throws Exception {
-        IdentityProvider credentialsProvider = mock(IdentityProvider.class);
-        S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
-        S3AccessGrantsCachedCredentialsProvider testCache = mock(S3AccessGrantsCachedCredentialsProvider.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_DISABLED, localS3ControlClient, testCache, TEST_FALLBACK_ENABLED, metricsPublisher);
-        ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
-        CompletableFuture<GetDataAccessResponse> getDataAccessResponse = CompletableFuture.supplyAsync(() -> GetDataAccessResponse.builder()
-                .credentials(Credentials.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).sessionToken(TEST_SESSION_TOKEN).build()).build());
-
-        when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(getDataAccessResponse);
-        when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build()));
-        when(testCache.getDataAccess(any(), any(), any(), any())).thenReturn(null);
-
-        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join());
-
-        verify(testCache, never()).getDataAccess(any(), any(), any(), any());
-    }
 
     @Test
     public void call_access_grants_identity_provider_with_cache_enabled_request_success() throws Exception {
 
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
+        S3ControlAsyncClientBuilder localS3ControlClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
         S3AccessGrantsCachedCredentialsProvider testCache = mock(S3AccessGrantsCachedCredentialsProvider.class);
         MetricPublisher testMetricPublisher = mock(MetricPublisher.class);
         MetricCollector testMetricCollector = mock(MetricCollector.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClient, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClientBuilder, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
         AwsCredentialsIdentity credentials = AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build();
         CompletableFuture<AwsCredentialsIdentity> cacheResponse = CompletableFuture.supplyAsync(() -> credentials);
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
-        when(testCache.getDataAccess(any(), any(), any(), any())).thenReturn(cacheResponse);
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2)).thenReturn(localS3ControlClientBuilder);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2).build()).thenReturn(localS3ControlClient);
+        when(testCache.getDataAccess(any(), any(), any(), any(), any())).thenReturn(cacheResponse);
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> {
             return credentials;
         }));
@@ -399,7 +340,7 @@ public class S3AccessGrantsIdentityProviderTests {
         when(testMetricCollector.collect()).thenReturn(mock(MetricCollection.class));
 
         Assertions.assertThatNoException().isThrownBy(() -> accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join());
-        verify(testCache, times(1)).getDataAccess(any(), any(), any(), any());
+        verify(testCache, times(1)).getDataAccess(any(), any(), any(), any(), any());
         verify(testMetricPublisher, times(1)).publish(any());
     }
 
@@ -407,13 +348,13 @@ public class S3AccessGrantsIdentityProviderTests {
     public void call_access_grants_identity_provider_with_cache_enabled_request_failure_returns_user_credentials() {
 
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
+        S3ControlAsyncClientBuilder localS3ControlClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
         S3AccessGrantsCachedCredentialsProvider testCache = S3AccessGrantsCachedCredentialsProviderImpl
                 .builder()
-                .S3ControlAsyncClient(localS3ControlClient)
                 .build();
         MetricPublisher testMetricPublisher = mock(MetricPublisher.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClient, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClientBuilder, testCache, !TEST_FALLBACK_ENABLED, testMetricPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
         AwsCredentialsIdentity credentials = AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build();
         CompletableFuture<GetAccessGrantsInstanceForPrefixResponse>  getAccessGrantsInstanceForPrefixResponse = CompletableFuture.supplyAsync(() -> GetAccessGrantsInstanceForPrefixResponse.builder()
@@ -421,7 +362,10 @@ public class S3AccessGrantsIdentityProviderTests {
                 .accessGrantsInstanceId("default").build());
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2)).thenReturn(localS3ControlClientBuilder);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2).build()).thenReturn(localS3ControlClient);
         when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenThrow(InvalidRequestException.class);
         when(localS3ControlClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(getAccessGrantsInstanceForPrefixResponse);
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> credentials));
@@ -436,13 +380,13 @@ public class S3AccessGrantsIdentityProviderTests {
     public void call_access_grants_identity_provider_with_cache_enabled_request_failure_does_not_returns_user_credentials() {
 
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
+        S3ControlAsyncClientBuilder localS3ControlClientBuilder = mock(S3ControlAsyncClientBuilder.class);
         S3ControlAsyncClient localS3ControlClient = mock(S3ControlAsyncClient.class);
         S3AccessGrantsCachedCredentialsProvider testCache = S3AccessGrantsCachedCredentialsProviderImpl
                 .builder()
-                .S3ControlAsyncClient(localS3ControlClient)
                 .build();
         MetricPublisher testMetricPublisher = mock(MetricPublisher.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClient, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, localS3ControlClientBuilder, testCache, TEST_FALLBACK_ENABLED, testMetricPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
         AwsCredentialsIdentity credentials = AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build();
         CompletableFuture<GetAccessGrantsInstanceForPrefixResponse>  getAccessGrantsInstanceForPrefixResponse = CompletableFuture.supplyAsync(() -> GetAccessGrantsInstanceForPrefixResponse.builder()
@@ -450,7 +394,10 @@ public class S3AccessGrantsIdentityProviderTests {
                 .accessGrantsInstanceId("default").build());
 
         when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn(TEST_OPERATION);
+        when(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY)).thenReturn(Region.US_EAST_2);
+        when(resolveIdentityRequest.property(PERMISSION_PROPERTY)).thenReturn(Permission.READ);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2)).thenReturn(localS3ControlClientBuilder);
+        when(localS3ControlClientBuilder.region(Region.US_EAST_2).build()).thenReturn(localS3ControlClient);
         when(localS3ControlClient.getDataAccess(any(GetDataAccessRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> GetDataAccessResponse.builder().build()).whenComplete((r,e) -> { throw InvalidRequestException.builder().statusCode(400).build(); }));
         when(localS3ControlClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(getAccessGrantsInstanceForPrefixResponse);
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> credentials));
@@ -462,12 +409,11 @@ public class S3AccessGrantsIdentityProviderTests {
     @Test
     public void call_access_grants_identity_provider_with_unsupported_operation() {
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, !TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, !TEST_FALLBACK_ENABLED, metricsPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
         AwsCredentialsIdentity credentials = AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build();
 
-        when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn("CreateBucket");
+        when(resolveIdentityRequest.property(AUTH_EXCEPTIONS_PROPERTY)).thenReturn(SdkServiceException.builder().statusCode(404).cause(new UnsupportedOperationException()).build());
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> credentials));
 
         AwsCredentialsIdentity awsCredentialsIdentity = accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join();
@@ -478,17 +424,15 @@ public class S3AccessGrantsIdentityProviderTests {
     @Test
     public void call_access_grants_identity_provider_with_unsupported_operation_on_disabled_fallback() {
         IdentityProvider credentialsProvider = mock(IdentityProvider.class);
-        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, TEST_REGION, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlClient, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
+        S3AccessGrantsIdentityProvider accessGrantsIdentityProvider = new S3AccessGrantsIdentityProvider(credentialsProvider, stsAsyncClient, TEST_PRIVILEGE, TEST_CACHE_ENABLED, s3ControlAsyncClientBuilder, cache, TEST_FALLBACK_ENABLED, metricsPublisher);
         ResolveIdentityRequest resolveIdentityRequest = mock(ResolveIdentityRequest.class);
         AwsCredentialsIdentity credentials = AwsCredentialsIdentity.builder().accessKeyId(TEST_ACCESS_KEY).secretAccessKey(TEST_SECRET_KEY).build();
 
-        when(resolveIdentityRequest.property(PREFIX_PROPERTY)).thenReturn("s3://test-bucket");
-        when(resolveIdentityRequest.property(OPERATION_PROPERTY)).thenReturn("CreateBucket");
+        when(resolveIdentityRequest.property(AUTH_EXCEPTIONS_PROPERTY)).thenReturn(SdkServiceException.builder().statusCode(404).cause(new UnsupportedOperationException()).build());
         when(credentialsProvider.resolveIdentity(any(ResolveIdentityRequest.class))).thenReturn(CompletableFuture.supplyAsync(() -> credentials));
 
         AwsCredentialsIdentity awsCredentialsIdentity = accessGrantsIdentityProvider.resolveIdentity(resolveIdentityRequest).join();
         Assertions.assertThat(awsCredentialsIdentity.secretAccessKey()).isEqualTo(TEST_SECRET_KEY);
         Assertions.assertThat(awsCredentialsIdentity.accessKeyId()).isEqualTo(TEST_ACCESS_KEY);
     }
-
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -135,8 +135,7 @@ public class S3AccessGrantsPluginTests {
                 .region(null);
 
 
-        Assertions.assertThatThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration))
-                .isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
 
     }
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -44,6 +44,7 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
     }
 
     @Test
@@ -51,6 +52,15 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableFallback(true).build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isTrue();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
+    }
+
+    @Test
+    public void create_access_grants_plugin_with_cross_region_access_specified() {
+        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableCrossRegionAccess(true).build();
+        Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
+        Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isTrue();
     }
 
     @Test
@@ -78,7 +88,6 @@ public class S3AccessGrantsPluginTests {
                .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                .credentialsProvider(DefaultCredentialsProvider.create())
                .region(Region.US_EAST_2);
-
 
        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
 


### PR DESCRIPTION
- refactoring the components to support the cross-region support for the plugin.
- Adding and refactoring test suite to support the cross-region changes.
- Updating README
- Adding an STS cache to reduce throttles to STS.


**Issue #, if available:**

In the current-scenario, the plugin configures the region on the clients limiting the cross-region access of the buckets i.e. all configurations are done at the time of plugin instantiation rather than making the decisions on each request. The changes will add cross-region support for the plugin by making regional decisions for each request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
