### PR TITLE
cross-region-support-cache level changes

### DIFF
--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolver.java
@@ -12,20 +12,22 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package software.amazon.awssdk.s3accessgrants.cache;
 
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 
-public interface S3AccessGrantsAccountIdResolver {
+public interface S3AccessGrantsBucketRegionResolver {
+
     /**
      *
-     * @param accountId AWS AccountId from the request context parameter
-     * @param s3Prefix e.g., s3://bucket-name/path/to/helloworld.txt
-     * @param s3ControlAsyncClient S3ControlAsynClient that will be used for making the requests
-     * @return AWS AccountId of the S3 Access Grants Instance that owns the location scope of the s3Prefix
-     * @throws S3ControlException propagate S3ControlException from service call
+     * @param bucket name of the bucket being accessed
+     * @throws S3Exception propagate S3Exception from service call
      */
-    String resolve(String accountId, String s3Prefix, S3ControlAsyncClient s3ControlAsyncClient) throws S3ControlException;
+
+    Region resolve(String bucket) throws S3Exception;
+
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
@@ -41,16 +41,11 @@ import software.amazon.awssdk.utils.Logger;
  */
 public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAccountIdResolver {
 
-    private final S3ControlAsyncClient S3ControlAsyncClient;
     private int maxCacheSize;
     private int expireCacheAfterWriteSeconds;
     private static final Logger logger = Logger.loggerFor(S3AccessGrantsCachedAccountIdResolver.class);
 
     private Cache<String, String> cache;
-
-    public S3ControlAsyncClient S3ControlAsyncClient() {
-        return S3ControlAsyncClient;
-    }
 
     public int maxCacheSize() {
         return maxCacheSize;
@@ -63,11 +58,7 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
     protected CacheStats getCacheStats() { return cache.stats(); }
 
     @VisibleForTesting
-    S3AccessGrantsCachedAccountIdResolver(@NotNull S3ControlAsyncClient S3ControlAsyncClient) {
-        if (S3ControlAsyncClient == null) {
-            throw new IllegalArgumentException("S3ControlAsyncClient is required");
-        }
-        this.S3ControlAsyncClient = S3ControlAsyncClient;
+    S3AccessGrantsCachedAccountIdResolver() {
         this.maxCacheSize = DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE;
         this.expireCacheAfterWriteSeconds = DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
     }
@@ -82,12 +73,15 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
     }
 
     @Override
-    public String resolve(String accountId, String s3Prefix) {
+    public String resolve(String accountId, String s3Prefix, S3ControlAsyncClient s3ControlAsyncClient) {
         String bucketName = getBucketName(s3Prefix);
         String s3PrefixAccountId = cache.getIfPresent(bucketName);
         if (s3PrefixAccountId == null) {
             logger.debug(()->"Account Id not available in the cache. Fetching account from server.");
-            s3PrefixAccountId = resolveFromService(accountId, s3Prefix);
+            if (s3ControlAsyncClient == null) {
+                throw new IllegalArgumentException("S3ControlAsyncClient is required for the access grants instance account resolver!");
+            }
+            s3PrefixAccountId = resolveFromService(accountId, s3Prefix, s3ControlAsyncClient);
             cache.put(bucketName, s3PrefixAccountId);
         }
         return s3PrefixAccountId;
@@ -98,9 +92,9 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
      * @param s3Prefix e.g., s3://bucket-name/path/to/helloworld.txt
      * @return accountId from the service response
      */
-    private String resolveFromService(String accountId, String s3Prefix) {
+    private String resolveFromService(String accountId, String s3Prefix, S3ControlAsyncClient s3ControlAsyncClient) {
         CompletableFuture<GetAccessGrantsInstanceForPrefixResponse> accessGrantsInstanceForPrefix =
-            S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(GetAccessGrantsInstanceForPrefixRequest
+                s3ControlAsyncClient.getAccessGrantsInstanceForPrefix(GetAccessGrantsInstanceForPrefixRequest
                                                                  .builder()
                                                                  .accountId(accountId)
                                                                  .s3Prefix(s3Prefix)
@@ -117,8 +111,6 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
     public interface Builder {
         S3AccessGrantsCachedAccountIdResolver build();
 
-        Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient);
-
         Builder maxCacheSize(int maxCacheSize);
 
         Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds);
@@ -133,15 +125,8 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
         }
 
         public BuilderImpl(S3AccessGrantsCachedAccountIdResolver s3AccessGrantsCachedAccountIdResolver) {
-            S3ControlAsyncClient(s3AccessGrantsCachedAccountIdResolver.S3ControlAsyncClient);
             maxCacheSize(s3AccessGrantsCachedAccountIdResolver.maxCacheSize);
             expireCacheAfterWriteSeconds(s3AccessGrantsCachedAccountIdResolver.expireCacheAfterWriteSeconds);
-        }
-
-        @Override
-        public Builder S3ControlAsyncClient(S3ControlAsyncClient S3ControlAsyncClient) {
-            this.S3ControlAsyncClient = S3ControlAsyncClient;
-            return this;
         }
 
         public int maxCacheSize() {
@@ -174,7 +159,7 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
 
         @Override
         public S3AccessGrantsCachedAccountIdResolver build() {
-            S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver(S3ControlAsyncClient);
+            S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver();
             resolver.maxCacheSize = maxCacheSize();
             resolver.expireCacheAfterWriteSeconds = expireCAcheAfterWriteSeconds();
             resolver.cache = Caffeine.newBuilder()

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
@@ -32,6 +32,10 @@ import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstant
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
 
+/*
+* A layer for caching bucket regions.
+* This cache is specifically to avoid head bucket throttling.
+* */
 public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsBucketRegionResolver {
 
 
@@ -151,6 +155,10 @@ public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsB
             return s3Client;
         }
 
+        public int expireCacheAfterWriteSeconds() {
+            return expireCacheAfterWriteSeconds;
+        }
+
         @Override
         public S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize) {
             if (maxCacheSize <= 0 || maxCacheSize > MAX_BUCKET_REGION_CACHE_SIZE) {
@@ -162,16 +170,12 @@ public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsB
         }
 
         @Override
-        public Builder s3Client(S3Client s3Client) {
-            if(s3Client == null) throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
+        public S3AccessGrantsCachedBucketRegionResolver.Builder s3Client(S3Client s3Client) {
+            if (s3Client == null)
+                throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
             this.s3Client = s3Client;
             return this;
         }
-
-        public int expireCacheAfterWriteSeconds() {
-            return expireCacheAfterWriteSeconds;
-        }
-
         @Override
         public S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds) {
             if (expireCacheAfterWriteSeconds <= 0 || expireCacheAfterWriteSeconds > MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS) {

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedBucketRegionResolver.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.utils.Logger;
+
+import java.time.Duration;
+
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
+
+public class S3AccessGrantsCachedBucketRegionResolver implements S3AccessGrantsBucketRegionResolver {
+
+
+    private int maxCacheSize;
+
+    private int expireCacheAfterWriteSeconds;
+
+    private Cache<String, Region> cache;
+
+    private S3Client s3Client;
+
+    private static final Logger logger = Logger.loggerFor(S3AccessGrantsCachedBucketRegionResolver.class);
+
+    public int getMaxCacheSize() {
+        return maxCacheSize;
+    }
+
+
+    public int getExpireCacheAfterWriteSeconds() {
+        return expireCacheAfterWriteSeconds;
+    }
+
+    public int expireCacheAfterWriteSeconds() {
+        return expireCacheAfterWriteSeconds;
+    }
+
+    public int maxCacheSize() {
+        return maxCacheSize;
+    }
+
+    protected CacheStats getCacheStats() { return cache.stats(); }
+
+    public S3AccessGrantsCachedBucketRegionResolver.Builder toBuilder() {
+        return new S3AccessGrantsCachedBucketRegionResolver.BuilderImpl(this);
+    }
+
+    public static S3AccessGrantsCachedBucketRegionResolver.Builder builder() {
+        return new S3AccessGrantsCachedBucketRegionResolver.BuilderImpl();
+    }
+
+    private S3AccessGrantsCachedBucketRegionResolver() {
+        this.maxCacheSize = BUCKET_REGION_CACHE_SIZE;
+        this.expireCacheAfterWriteSeconds = BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+    }
+
+    @Override
+    public Region resolve(String bucket) throws S3Exception {
+        Region bucketRegion = cache.getIfPresent(bucket);
+        if(bucketRegion == null) {
+            logger.debug(() -> "bucket region not available in cache, fetching the region from the service!");
+            if (s3Client == null) {
+                throw new IllegalArgumentException("S3Client is required for the bucket region resolver!");
+            }
+            bucketRegion = resolveFromService(bucket);
+            if(bucketRegion != null) {
+                cache.put(bucket, bucketRegion);
+            }
+        } else {
+            logger.debug(() -> "bucket region available in cache!");
+        }
+        return bucketRegion;
+
+    }
+
+    private Region resolveFromService(String bucket) {
+        String resolvedRegion = null;
+        try {
+                logger.info(() -> "making a call to S3 for determining the bucket region!");
+                HeadBucketRequest bucketLocationRequest = HeadBucketRequest.builder().bucket(bucket).build();
+                HeadBucketResponse headBucketResponse = s3Client.headBucket(bucketLocationRequest);
+                resolvedRegion = headBucketResponse.bucketRegion();
+        } catch (S3Exception e) {
+            if (e.statusCode() == 301) {
+                // A fallback in case S3 Clients are not able to re-direct the head bucket requests to the correct region.
+                String bucketRegion = e.awsErrorDetails().sdkHttpResponse().headers().get("x-amz-bucket-region").get(0);
+                resolvedRegion = bucketRegion;
+            } else {
+                throw e;
+            }
+        }
+        if(resolvedRegion == null) throw SdkServiceException.builder().message("S3 error! region cannot be determined for the specified bucket!").build();
+        return Region.of(resolvedRegion);
+    }
+
+
+    public interface Builder {
+        S3AccessGrantsCachedBucketRegionResolver build();
+
+        S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize);
+
+        S3AccessGrantsCachedBucketRegionResolver.Builder s3Client(S3Client s3Client);
+
+        S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds);
+    }
+
+    static final class BuilderImpl implements S3AccessGrantsCachedBucketRegionResolver.Builder {
+        private int maxCacheSize = BUCKET_REGION_CACHE_SIZE;
+        private int expireCacheAfterWriteSeconds = BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+
+        private S3Client s3Client;
+
+        private BuilderImpl() {
+        }
+
+        public BuilderImpl(S3AccessGrantsCachedBucketRegionResolver s3AccessGrantsCachedBucketRegionResolver) {
+            maxCacheSize(s3AccessGrantsCachedBucketRegionResolver.maxCacheSize);
+            expireCacheAfterWriteSeconds(s3AccessGrantsCachedBucketRegionResolver.expireCacheAfterWriteSeconds);
+            s3Client(s3AccessGrantsCachedBucketRegionResolver.s3Client);
+        }
+
+        public int maxCacheSize() {
+            return maxCacheSize;
+        }
+
+        public S3Client s3Client() {
+            if(s3Client == null) throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
+            return s3Client;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver.Builder maxCacheSize(int maxCacheSize) {
+            if (maxCacheSize <= 0 || maxCacheSize > MAX_BUCKET_REGION_CACHE_SIZE) {
+                throw new IllegalArgumentException(String.format("maxCacheSize needs to be in range (0, %d]",
+                        MAX_BUCKET_REGION_CACHE_SIZE));
+            }
+            this.maxCacheSize = maxCacheSize;
+            return this;
+        }
+
+        @Override
+        public Builder s3Client(S3Client s3Client) {
+            if(s3Client == null) throw new IllegalArgumentException("S3 Client is required while configuring the S3 Bucket Region resolver!");
+            this.s3Client = s3Client;
+            return this;
+        }
+
+        public int expireCacheAfterWriteSeconds() {
+            return expireCacheAfterWriteSeconds;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver.Builder expireCacheAfterWriteSeconds(int expireCacheAfterWriteSeconds) {
+            if (expireCacheAfterWriteSeconds <= 0 || expireCacheAfterWriteSeconds > MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS) {
+                throw new IllegalArgumentException(String.format("expireCacheAfterWriteSeconds needs to be in range (0, %d]",
+                        MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS));
+            }
+            this.expireCacheAfterWriteSeconds = expireCacheAfterWriteSeconds;
+            return this;
+        }
+
+        @Override
+        public S3AccessGrantsCachedBucketRegionResolver build() {
+            S3AccessGrantsCachedBucketRegionResolver resolver = new S3AccessGrantsCachedBucketRegionResolver();
+            resolver.maxCacheSize = maxCacheSize();
+            resolver.expireCacheAfterWriteSeconds = expireCacheAfterWriteSeconds();
+            resolver.s3Client = s3Client();
+            resolver.cache = Caffeine.newBuilder()
+                    .maximumSize(maxCacheSize)
+                    .expireAfterWrite(Duration.ofSeconds(expireCacheAfterWriteSeconds))
+                    .build();
+            return resolver;
+        }
+    }
+
+}

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProvider.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.s3accessgrants.cache;
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.metrics.MetricCollector;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
 import software.amazon.awssdk.services.s3control.model.Permission;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 
@@ -27,11 +28,12 @@ public interface S3AccessGrantsCachedCredentialsProvider {
      * @param credentials Credentials used for calling Access Grants.
      * @param permission Permission requested by the user. Can be Read, Write, or ReadWrite.
      * @param s3Prefix S3Prefix requested by the user. e.g., s3://bucket-name/path/to/helloworld.txt
+     * @param s3ControlAsyncClient S3ControlAsynClient that will be used for making the requests
      * @return Credentials from Access Grants.
      * @throws S3ControlException in-case exception is cached.
      */
     CompletableFuture<AwsCredentialsIdentity> getDataAccess (AwsCredentialsIdentity credentials, Permission permission, String s3Prefix,
-                                                             String accountId) throws Exception;
+                                                             String accountId, S3ControlAsyncClient s3ControlAsyncClient) throws Exception;
 
     /**
      * @return metrics collected by access grants cache jar

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsConstants.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.s3accessgrants.cache;
 public class S3AccessGrantsConstants {
     public static final int DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE = 1_000;
     public static final int MAX_LIMIT_ACCOUNT_ID_MAX_CACHE_SIZE = 1_000_000;
-    public static final int DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 86_400; // one day
+    public static final int DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 6_00; // 10 mins
     public static final int MAX_LIMIT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 2_592_000; // 30 days
 
     public static final int DEFAULT_ACCESS_GRANTS_MAX_CACHE_SIZE = 30_000;
@@ -26,5 +26,13 @@ public class S3AccessGrantsConstants {
     public static final int CACHE_EXPIRATION_TIME_PERCENTAGE = 90;
 
     public static final int ACCESS_DENIED_CACHE_SIZE = 3_000;
+
+    public static final int BUCKET_REGION_CACHE_SIZE = 1_000;
+
+    public static final int MAX_BUCKET_REGION_CACHE_SIZE = 1_000_000;
+
+    public static final int MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS = 6_00; // 10 mins
+
+    public static final int BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS= 3_00; // 5 mins
 
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
@@ -6,14 +6,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
-import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.*;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_CACHE_SIZE;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
 
 public class S3AccessGrantsBucketRegionResolverCreationTest {
 
-    private static int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
-    private static int TEST_CACHE_EXPIRATION_DURATION = 6_0;
+    private static final int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
+    private static final int TEST_CACHE_EXPIRATION_DURATION = 6_0;
 
     private static S3Client s3Client;
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverCreationTest.java
@@ -1,0 +1,117 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.*;
+
+public class S3AccessGrantsBucketRegionResolverCreationTest {
+
+    private static int TEST_BUCKET_REGION_CACHE_SIZE = 5_000;
+    private static int TEST_CACHE_EXPIRATION_DURATION = 6_0;
+
+    private static S3Client s3Client;
+
+    @BeforeClass
+    public static void setUp() {
+        s3Client = mock(S3Client.class);
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_default_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
+        Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_custom_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .s3Client(s3Client)
+                .build();
+        Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_builder_default_settings() {
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
+        Assert.assertEquals(BUCKET_REGION_CACHE_SIZE, cachedBucketRegionResolver.getMaxCacheSize());
+        Assert.assertEquals(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS, cachedBucketRegionResolver.getExpireCacheAfterWriteSeconds());
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_invalid_max_cache_size() {
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(MAX_BUCKET_REGION_CACHE_SIZE+1)
+                .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .s3Client(s3Client)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(0)
+                .expireCacheAfterWriteSeconds(BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS)
+                .s3Client(s3Client)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void create_bucket_region_cache_with_invalid_expiration_duration() {
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(MAX_BUCKET_REGION_EXPIRE_CACHE_AFTER_WRITE_SECONDS+10)
+                .s3Client(s3Client)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+        Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(0)
+                .s3Client(s3Client)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void copy_Resolver() {
+
+        S3AccessGrantsCachedBucketRegionResolver cachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .s3Client(s3Client)
+                .build();
+        S3AccessGrantsCachedBucketRegionResolver copy = cachedBucketRegionResolver.toBuilder().build();
+
+        Assert.assertEquals(TEST_BUCKET_REGION_CACHE_SIZE, copy.maxCacheSize());
+        Assert.assertEquals(TEST_CACHE_EXPIRATION_DURATION, copy.expireCacheAfterWriteSeconds());
+
+    }
+
+    @Test
+    public void test_invalidS3Client() {
+       Assertions.assertThatThrownBy(() -> S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .maxCacheSize(TEST_BUCKET_REGION_CACHE_SIZE)
+                .s3Client(null)
+                .expireCacheAfterWriteSeconds(TEST_CACHE_EXPIRATION_DURATION)
+                .build()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+}
+
+

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -1,0 +1,126 @@
+package software.amazon.awssdk.s3accessgrants.cache;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class S3AccessGrantsBucketRegionResolverTest {
+
+    private S3Client s3Client;
+    private S3AccessGrantsCachedBucketRegionResolver s3AccessGrantsCachedBucketRegionResolver;
+    private String TEST_BUCKET_NAME;
+
+    @Before
+    public void setUp() {
+        s3Client = mock(S3Client.class);
+        TEST_BUCKET_NAME = "test-bucket";
+        s3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
+        HeadBucketResponse headBucketResponse = HeadBucketResponse.builder().bucketRegion(Region.US_EAST_1.toString()).build();
+        when(s3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(headBucketResponse);
+    }
+
+    @Test
+    public void call_resolve_should_cache_the_bucket_region() {
+        Assert.assertEquals(s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME), Region.US_EAST_1);
+        // initial request should be made to the service
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Assert.assertEquals(s3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME), Region.US_EAST_1);
+        // No call should be made to the service as the region is already cached
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+    }
+
+    @Test
+    public void call_resolve_should_not_cache_the_bucket_region() {
+        S3Client localS3Client = mock(S3Client.class);
+        S3AccessGrantsCachedBucketRegionResolver localS3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(localS3Client).build();
+        HeadBucketResponse headBucketResponse = HeadBucketResponse.builder().bucketRegion(null).build();
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(headBucketResponse);
+        Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME)).isInstanceOf(SdkServiceException.class);
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME)).isInstanceOf(SdkServiceException.class);
+        verify(localS3Client, times(2)).headBucket(any(HeadBucketRequest.class));
+    }
+
+    @Test
+    public void verify_bucket_region_cache_expiration() throws InterruptedException {
+
+        S3AccessGrantsCachedBucketRegionResolver localCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver
+                .builder()
+                .s3Client(s3Client)
+                .expireCacheAfterWriteSeconds(1)
+                .build();
+
+        Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME));
+        verify(s3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        Thread.sleep(2000);
+        // should evict the entry and the subsequent request should call the service
+        Assert.assertEquals(Region.US_EAST_1, localCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME));
+        verify(s3Client, times(2)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_with_non_existent_bucket() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        S3AccessGrantsCachedBucketRegionResolver localS3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(localS3Client).build();
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(S3Exception.builder().message("Bucket does not exist").statusCode(404).build());
+        Assertions.assertThatThrownBy(() ->  localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME)).isInstanceOf(S3Exception.class);
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_resolve_returns_redirect() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        AwsServiceException s3Exception = mock(S3Exception.class);
+        S3AccessGrantsCachedBucketRegionResolver localS3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(localS3Client).build();
+        List<String> regionList = new ArrayList<>();
+        regionList.add(Region.US_EAST_1.toString());
+        SdkHttpResponse sdkHttpResponse = SdkHttpResponse.builder().putHeader("x-amz-bucket-region", regionList).build();
+        AwsErrorDetails awsErrorDetails = AwsErrorDetails.builder().sdkHttpResponse(sdkHttpResponse).build();
+        when(s3Exception.statusCode()).thenReturn(301);
+        when(s3Exception.awsErrorDetails()).thenReturn(awsErrorDetails);
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception);
+        Assert.assertEquals(Region.US_EAST_1, localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME));
+        verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_bucket_region_cache_resolve_returns_redirect_with_null_region() throws InterruptedException {
+
+        S3Client localS3Client = mock(S3Client.class);
+        AwsServiceException s3Exception = mock(S3Exception.class);
+        S3AccessGrantsCachedBucketRegionResolver localS3AccessGrantsCachedBucketRegionResolver = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(localS3Client).build();
+        List<String> regionList = new ArrayList<>();
+        regionList.add(null);
+        SdkHttpResponse sdkHttpResponse = SdkHttpResponse.builder().putHeader("x-amz-bucket-region", regionList).build();
+        AwsErrorDetails awsErrorDetails = AwsErrorDetails.builder().sdkHttpResponse(sdkHttpResponse).build();
+        when(s3Exception.statusCode()).thenReturn(301);
+        when(s3Exception.awsErrorDetails()).thenReturn(awsErrorDetails);
+        when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception);
+        Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME))
+                .isInstanceOf(SdkServiceException.class);
+
+    }
+
+}

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -56,6 +56,7 @@ public class S3AccessGrantsBucketRegionResolverTest {
         when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenReturn(headBucketResponse);
         Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME)).isInstanceOf(SdkServiceException.class);
         verify(localS3Client, times(1)).headBucket(any(HeadBucketRequest.class));
+        // since bucket region is null, cache will not store the entry
         Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME)).isInstanceOf(SdkServiceException.class);
         verify(localS3Client, times(2)).headBucket(any(HeadBucketRequest.class));
     }
@@ -120,6 +121,7 @@ public class S3AccessGrantsBucketRegionResolverTest {
         when(s3Exception.statusCode()).thenReturn(301);
         when(s3Exception.awsErrorDetails()).thenReturn(awsErrorDetails);
         when(localS3Client.headBucket(any(HeadBucketRequest.class))).thenThrow(s3Exception);
+        // resolving that exceptions are thrown when bucket region cannot be determined.
         Assertions.assertThatThrownBy(() -> localS3AccessGrantsCachedBucketRegionResolver.resolve(TEST_BUCKET_NAME))
                 .isInstanceOf(SdkServiceException.class);
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsBucketRegionResolverTest.java
@@ -3,7 +3,6 @@ package software.amazon.awssdk.s3accessgrants.cache;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
@@ -19,7 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
 
 public class S3AccessGrantsBucketRegionResolverTest {
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverCreationTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.s3accessgrants.cache;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsConstants.DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS;
@@ -34,27 +35,18 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
     }
 
     @Test
-    public void create_DefaultResolver_without_S3ControlAsyncClient_via_Constructor() {
-        // Given
-        S3ControlAsyncClient = null;
-        // Then
-        assertThatIllegalArgumentException().isThrownBy(() -> new S3AccessGrantsCachedAccountIdResolver(S3ControlAsyncClient));
-    }
-
-    @Test
     public void create_DefaultResolver_via_Constructor() {
         // When
-        S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver(S3ControlAsyncClient);
+        S3AccessGrantsCachedAccountIdResolver resolver = new S3AccessGrantsCachedAccountIdResolver();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS);
     }
 
     @Test
     public void create_Resolver_via_Builder() {
-        assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
+        assertThatNoException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
             .build());
     }
@@ -64,9 +56,8 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Given
         S3ControlAsyncClient = null;
         //Then
-        assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
+        assertThatNoException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build());
     }
 
@@ -75,11 +66,9 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(DEFAULT_ACCOUNT_ID_MAX_CACHE_SIZE);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(DEFAULT_ACCOUNT_ID_EXPIRE_CACHE_AFTER_WRITE_SECONDS);
     }
@@ -92,13 +81,11 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build();
         // Then
         assertThat(resolver).isNotNull();
-        assertThat(resolver.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(resolver.maxCacheSize()).isEqualTo(customMaxCacheSize);
         assertThat(resolver.expireCacheAfterWriteSeconds()).isEqualTo(customExpireCacheAfterWriteSeconds);
     }
@@ -110,7 +97,6 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Then
         assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .build());
     }
@@ -122,7 +108,6 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // Then
         assertThatIllegalArgumentException().isThrownBy(() -> S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build());
     }
@@ -135,14 +120,12 @@ public class S3AccessGrantsCachedAccountIdResolverCreationTest {
         // When
         S3AccessGrantsCachedAccountIdResolver resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .maxCacheSize(customMaxCacheSize)
             .expireCacheAfterWriteSeconds(customExpireCacheAfterWriteSeconds)
             .build();
         S3AccessGrantsCachedAccountIdResolver copy = resolver.toBuilder().build();
         // Then
         assertThat(copy).isNotNull();
-        assertThat(copy.S3ControlAsyncClient()).isEqualTo(S3ControlAsyncClient);
         assertThat(copy.maxCacheSize()).isEqualTo(customMaxCacheSize);
         assertThat(copy.expireCacheAfterWriteSeconds()).isEqualTo(customExpireCacheAfterWriteSeconds);
     }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverTest.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolverTest.java
@@ -47,7 +47,6 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         S3ControlAsyncClient = Mockito.mock(S3ControlAsyncClient.class);
         resolver = S3AccessGrantsCachedAccountIdResolver
             .builder()
-            .S3ControlAsyncClient(S3ControlAsyncClient)
             .build();
     }
 
@@ -64,7 +63,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class)))
             .thenReturn(response);
         // When
-        String accountId = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
+        String accountId = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
         // Then
         assertThat(accountId).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         verify(S3ControlAsyncClient, times(1)).getAccessGrantsInstanceForPrefix(requestArgumentCaptor.capture());
@@ -84,8 +83,8 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                                                         .accessGrantsInstanceArn(TEST_S3_ACCESSGRANTS_INSTANCE_ARN).build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // When attempting to resolve same prefix back to back
-        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
-        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
+        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
+        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
         // Then
         assertThat(accountId1).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         assertThat(accountId2).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
@@ -105,8 +104,8 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                     .accessGrantsInstanceArn(TEST_S3_ACCESSGRANTS_INSTANCE_ARN).build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // When attempting to resolve same prefix back to back
-        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX);
-        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX_2);
+        String accountId1 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient);
+        String accountId2 = resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX_2, S3ControlAsyncClient);
         // Then
         assertThat(accountId1).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
         assertThat(accountId2).isEqualTo(TEST_S3_ACCESSGRANTS_ACCOUNT);
@@ -120,7 +119,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class)))
             .thenThrow(S3ControlException.builder().build());
         // Then
-        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX)).isInstanceOf(S3ControlException.class);
+        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient)).isInstanceOf(S3ControlException.class);
 
     }
 
@@ -133,7 +132,7 @@ public class S3AccessGrantsCachedAccountIdResolverTest {
                                                     .accessGrantsInstanceArn("").build());
         when(S3ControlAsyncClient.getAccessGrantsInstanceForPrefix(any(GetAccessGrantsInstanceForPrefixRequest.class))).thenReturn(response);
         // Then
-        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX)).isInstanceOf(S3ControlException.class);
+        assertThatThrownBy(() -> resolver.resolve(TEST_S3_ACCESSGRANTS_ACCOUNT, TEST_S3_PREFIX, S3ControlAsyncClient)).isInstanceOf(S3ControlException.class);
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*
Currently, the design for the caching layer only accepts a single instance of S3ControlClient during initializations. The problem with this is that, the S3ControlClient is configured for one region and cannot be used for making cross-region requests. Since, S3ControlClients do not have a cross-region setting to redirect requests to the correct region, we will be making headbucket requests to determine the correct region for the bucket and configure the S3ControlClient accordingly.

*Description of changes:*
* modifying the cache layers to remove passing S3ControlClients as part of the builder. Control Clients configured to the correct region will instead be passed as an input for the method that will be invoked by the plugin.
* Adding a Bucket Region cache. This region fetched for the bucket will be cached to avoid throttling S3 head bucket API.
* Adding and modifying unit tests.

*Testing:*
This PR is part of a large subset of PR's. Changes have been tested by running
* Unit-tests
* Integration-tests
* Spinning multiple threads in parallel sharing a single instance of s3client to send requests supported by Access Grants.

*Coverage:*
Cache layer - 86%


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
