### PR TITLE
cross-region-support plugin level changes

### DIFF
--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
@@ -20,4 +20,6 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 
 public interface Builder extends CopyableBuilder<Builder, S3AccessGrantsPlugin> {
     Builder enableFallback(Boolean choice);
+
+    Builder enableCrossRegionAccess(Boolean choice);
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -17,15 +17,27 @@ package software.amazon.awssdk.s3accessgrants.plugin;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import software.amazon.awssdk.annotations.NotNull;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedBucketRegionResolver;
+import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsOperationToPermissionMapper;
+import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsStaticOperationToPermissionMapper;
 import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeParams;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
+import software.amazon.awssdk.services.s3control.model.Permission;
 
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.BUCKET_LOCATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.logger;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.CONTACT_TEAM_MESSAGE_TEMPLATE;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.DEFAULT_CROSS_REGION_ACCESS_SETTING;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.AUTH_EXCEPTIONS_PROPERTY;
 
 
 /**
@@ -37,10 +49,23 @@ import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGran
 public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
 
     private final S3AuthSchemeProvider authSchemeProvider;
-    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider) {
+    private final S3Client s3Client;
+
+    private final Boolean isCrossRegionAccessEnabled;
+
+    private final S3AccessGrantsOperationToPermissionMapper permissionMapper;
+
+    private final S3AccessGrantsCachedBucketRegionResolver bucketRegionCache;
+
+    S3AccessGrantsAuthSchemeProvider(@NotNull S3AuthSchemeProvider authSchemeProvider, S3Client s3Client, Boolean isCrossRegionAccessEnabled) {
         S3AccessGrantsUtils.argumentNotNull(authSchemeProvider,
                 "Expecting an Auth Scheme Provider to be specified while configuring S3Clients!");
+        S3AccessGrantsUtils.argumentNotNull(s3Client, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "S3 Client", "Plugin"));
         this.authSchemeProvider = authSchemeProvider;
+        this.s3Client = s3Client;
+        this.isCrossRegionAccessEnabled = isCrossRegionAccessEnabled == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING : isCrossRegionAccessEnabled;
+        this.permissionMapper = new S3AccessGrantsStaticOperationToPermissionMapper();
+        this.bucketRegionCache = S3AccessGrantsCachedBucketRegionResolver.builder().s3Client(s3Client).build();
     }
 
     /**
@@ -54,16 +79,33 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
                 "An internal exception has occurred. Valid auth scheme params were not passed to the Auth Scheme Provider. Please contact the S3 Access Grants plugin team!");
 
         List<AuthSchemeOption> availableAuthSchemes = authSchemeProvider.resolveAuthScheme(authSchemeParams);
-        String S3Prefix = "s3://"+authSchemeParams.bucket()+"/"+getKeyIfExists(authSchemeParams);
 
-        return availableAuthSchemes.stream()
-                .map(authScheme -> authScheme.toBuilder().putIdentityProperty(OPERATION_PROPERTY,
-                                authSchemeParams.operation())
-                        .putIdentityProperty(PREFIX_PROPERTY,
-                                S3Prefix)
-                        .build()
-                )
-                .collect(Collectors.toList());
+        try {
+            final Permission permission = permissionMapper.getPermission(authSchemeParams.operation());
+
+            S3AccessGrantsUtils.argumentNotNull(authSchemeParams.bucket(), "Please specify a valid bucket name for the operation!");
+
+            final Region destinationRegion = getBucketLocation(authSchemeParams.bucket());
+
+            logger.debug(() -> "Access Grants requests will be sent to the region "+destinationRegion);
+            logger.debug(() -> "operation : " + authSchemeParams.operation());
+
+            String S3Prefix = "s3://"+authSchemeParams.bucket()+"/"+getKeyIfExists(authSchemeParams);
+
+            return availableAuthSchemes.stream()
+                    .map(authScheme -> authScheme.toBuilder()
+                            .putIdentityProperty(PREFIX_PROPERTY,
+                                    S3Prefix)
+                            .putIdentityProperty(BUCKET_LOCATION_PROPERTY, destinationRegion)
+                            .putIdentityProperty(PERMISSION_PROPERTY, permission)
+                            .build()
+                    )
+                    .collect(Collectors.toList());
+        } catch (SdkServiceException e) {
+            return availableAuthSchemes.stream()
+                    .map(authScheme -> authScheme.toBuilder().putIdentityProperty(AUTH_EXCEPTIONS_PROPERTY, e).build())
+                    .collect(Collectors.toList());
+        }
     }
 
     private String getKeyIfExists(S3AuthSchemeParams authSchemeParams) {
@@ -79,4 +121,22 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
         return keyDoesNotExists ? "*" : validKey;
 
     }
+
+    /**
+     * Fetch the location where the bucket is created.
+     * This is to ensure that the Access Grants requests are made to the correct region.
+     * @param bucketName bucket name in the users request
+     * @return Region where the S3 bucket exists
+     */
+    private Region getBucketLocation(String bucketName) {
+
+        if(isCrossRegionAccessEnabled) {
+            return bucketRegionCache.resolve(bucketName);
+        }
+
+        S3AccessGrantsUtils.argumentNotNull(s3Client.serviceClientConfiguration().region(), "Expecting a region to be configured on the S3Clients!");
+        return s3Client.serviceClientConfiguration().region();
+
+    }
+
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -16,10 +16,9 @@
 package software.amazon.awssdk.s3accessgrants.plugin;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import software.amazon.awssdk.annotations.NotNull;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
 import software.amazon.awssdk.identity.spi.IdentityProvider;
@@ -27,20 +26,19 @@ import software.amazon.awssdk.identity.spi.ResolveIdentityRequest;
 import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.s3accessgrants.cache.S3AccessGrantsCachedCredentialsProvider;
+import software.amazon.awssdk.services.s3control.S3ControlAsyncClientBuilder;
 import software.amazon.awssdk.services.s3control.model.Privilege;
 import software.amazon.awssdk.services.s3control.model.S3ControlException;
 import software.amazon.awssdk.services.s3control.model.Permission;
-import software.amazon.awssdk.services.s3control.model.GetDataAccessRequest;
-import software.amazon.awssdk.services.s3control.model.Credentials;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;
-import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsStaticOperationToPermissionMapper;
 import software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils;
 import software.amazon.awssdk.services.sts.StsAsyncClient;
-import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 import software.amazon.awssdk.utils.Validate;
 
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PERMISSION_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.AUTH_EXCEPTIONS_PROPERTY;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.BUCKET_LOCATION_PROPERTY;
 import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.logger;
 
 /**
@@ -51,17 +49,14 @@ import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGran
 public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCredentialsIdentity>{
 
     private final IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider;
-    private final Region region;
 
     private final Privilege privilege;
 
     private final Boolean isCacheEnabled;
 
-    private final S3ControlAsyncClient s3control;
+    private final S3ControlAsyncClientBuilder s3ControlBuilder;
 
     private final StsAsyncClient stsAsyncClient;
-
-    private final S3AccessGrantsStaticOperationToPermissionMapper permissionMapper;
 
     private final S3AccessGrantsCachedCredentialsProvider cache;
 
@@ -69,30 +64,35 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
 
     private final MetricPublisher metricsPublisher;
 
+    private final ConcurrentHashMap<Region, S3ControlAsyncClient> clientsCache;
+
+    private AwsCredentialsIdentity cachedCredentials;
+
+    private String cachedAccountId;
+
     private String CONTACT_TEAM_MESSAGE_TEMPLATE = "An internal exception has occurred. Valid %s was not passed to the %s. Please contact S3 access grants plugin team!";
 
     public S3AccessGrantsIdentityProvider(@NotNull IdentityProvider<? extends AwsCredentialsIdentity> credentialsProvider,
-                                          @NotNull Region region,
                                           @NotNull StsAsyncClient stsAsyncClient,
                                           @NotNull Privilege privilege,
                                           @NotNull Boolean isCacheEnabled,
-                                          @NotNull S3ControlAsyncClient s3ControlAsyncClient,
+                                          @NotNull S3ControlAsyncClientBuilder s3ControlAsyncClientBuilder,
                                           @NotNull S3AccessGrantsCachedCredentialsProvider cache,
                                           @NotNull boolean enableFallback,
-                                          @NotNull MetricPublisher metricsPublisher) {
+                                          @NotNull MetricPublisher metricsPublisher,
+                                          @NotNull ConcurrentHashMap<Region, S3ControlAsyncClient> clientsCache) {
         S3AccessGrantsUtils.argumentNotNull(credentialsProvider, "Expecting an Identity Provider to be specified while configuring S3Clients!");
-        S3AccessGrantsUtils.argumentNotNull(region, "Expecting a region to be configured on the S3Clients!");
         S3AccessGrantsUtils.argumentNotNull(stsAsyncClient, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "sts client", "identity provider"));
+        S3AccessGrantsUtils.argumentNotNull(clientsCache, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "client cache", "identity provider"));
         this.credentialsProvider = credentialsProvider;
-        this.region = region;
         this.stsAsyncClient = stsAsyncClient;
         this.privilege = privilege;
         this.isCacheEnabled = isCacheEnabled;
-        this.s3control = s3ControlAsyncClient;
-        this.permissionMapper = new S3AccessGrantsStaticOperationToPermissionMapper();
+        this.s3ControlBuilder = s3ControlAsyncClientBuilder;
         this.cache = cache;
         this.enableFallback = enableFallback;
         this.metricsPublisher = metricsPublisher;
+        this.clientsCache = clientsCache;
     }
 
     /**
@@ -124,96 +124,55 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
         CompletableFuture<? extends AwsCredentialsIdentity> userCredentials = null;
 
         try {
-            String accountId = getCallerAccountID().join().account();
 
-            validateRequestParameters(resolveIdentityRequest, accountId, privilege, isCacheEnabled);
+            if(resolveIdentityRequest != null && resolveIdentityRequest.property(AUTH_EXCEPTIONS_PROPERTY) != null) {
+                throw (SdkServiceException) resolveIdentityRequest.property(AUTH_EXCEPTIONS_PROPERTY);
+            }
 
             userCredentials = credentialsProvider.resolveIdentity(resolveIdentityRequest);
+            validateRequestParameters(resolveIdentityRequest, privilege, isCacheEnabled);
+            String accountId = getCallerAccountID(userCredentials);
 
             String S3Prefix = resolveIdentityRequest.property(PREFIX_PROPERTY).toString();
-            String operation = resolveIdentityRequest.property(OPERATION_PROPERTY).toString();
+            Permission permission = Permission.fromValue(resolveIdentityRequest.property(PERMISSION_PROPERTY).toString());
+            Region destinationRegion = Region.of(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY).toString());
+
+            S3ControlAsyncClient s3ControlAsyncClient = null;
+            CompletableFuture<? extends AwsCredentialsIdentity> getDataAccessResponse = null;
 
             logger.debug(() -> " Call access grants with the following request params! ");
             logger.debug(() -> " S3Prefix : " + S3Prefix);
             logger.debug(() -> " caller accountID : " + accountId);
-            logger.debug(() -> " operation : " + operation);
-
-            Permission permission = permissionMapper.getPermission(operation);
-
-            verifyIfValidBucket(S3Prefix);
-
             logger.debug(() -> " permission : " + permission);
+            logger.debug(() -> " bucket region : " + destinationRegion);
 
-            return isCacheEnabled ? getCredentialsFromCache(userCredentials.join(), permission, S3Prefix, accountId) : getCredentialsFromAccessGrants(createDataAccessRequest(accountId, S3Prefix, permission, privilege));
+            if(clientsCache.containsKey(destinationRegion)) {
+                getDataAccessResponse = getCredentialsFromCache(userCredentials.join(), permission, S3Prefix, accountId,  clientsCache.get(destinationRegion));
+            } else {
+                s3ControlAsyncClient = s3ControlBuilder.region(destinationRegion).build();
+                clientsCache.put(destinationRegion, s3ControlAsyncClient);
+                getDataAccessResponse = getCredentialsFromCache(userCredentials.join(), permission, S3Prefix, accountId,  s3ControlAsyncClient);
+            }
+
+            return getDataAccessResponse;
+
         } catch(SdkServiceException e) {
 
             if(shouldFallbackToDefaultCredentialsForThisCase(e.statusCode(), e.getCause())) {
-                return userCredentials;
+                return credentialsProvider.resolveIdentity(resolveIdentityRequest);
             }
             throw e;
         }
     }
 
     /**
-     * This method verifies if the user has specified a valid bucket for the operations supported by S3 Access Grants.
-     */
-    protected void verifyIfValidBucket(String prefix) {
-        if(prefix.split("/")[2].equals("null")) {
-            throw new IllegalArgumentException("Please specify a valid bucket name for the operation!");
-        }
-    }
-
-    /**
-     * This method will create a request to talk to access grants.
-     * @param accountId the accountId that contains the access grant instance with the desired bucket location registered.
-     * @param S3Prefix the resource that the requester is accessing.
-     * @param permission the permission level to access the resource. Permission is generated dynamically based on the
-     *                   operation. See {@link S3AccessGrantsStaticOperationToPermissionMapper} for operation to permission mappings.
-     * @param privilege specifies what privilege level does access grants need to use to determine if the request can be
-     *                  authorized. The default value for this is {@link Privilege} DEFAULT.
-     * @rturn the request created from the inputs.
-     * */
-    private GetDataAccessRequest createDataAccessRequest(String accountId,
-                                                         String S3Prefix,
-                                                         Permission permission,
-                                                         Privilege privilege) {
-        GetDataAccessRequest dataAccessRequest = GetDataAccessRequest.builder()
-                .accountId(accountId)
-                .target(S3Prefix)
-                .permission(permission)
-                .privilege(privilege)
-                .build();
-
-        return dataAccessRequest;
-    }
-
-    /**
-     * Maintenance Purpose - In case we want to make cache as a optional opt-out in the future.
-     * Sends a request to access grants to authorize if the requester has permissions to access the desired resource (S3Prefix).
-     * @param getDataAccessRequest the request to talk to access grants
-     * @return a completableFuture that resolves to credentials returned by access grants
-     * @throws S3ControlException for any request failures
-     * */
-    CompletableFuture<? extends AwsCredentialsIdentity> getCredentialsFromAccessGrants(GetDataAccessRequest getDataAccessRequest) {
-
-            S3AccessGrantsUtils.argumentNotNull(getDataAccessRequest, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "request", "for calling access grants"));
-            logger.debug(() -> " Calling S3 Access Grants to validate access permissions!");
-            return s3control.getDataAccess(getDataAccessRequest).thenApply(getDataAccessResponse -> {
-                Credentials credentials = getDataAccessResponse.credentials();
-                return AwsSessionCredentials.builder().accessKeyId(credentials.accessKeyId())
-                            .secretAccessKey(credentials.secretAccessKey())
-                            .sessionToken(credentials.sessionToken()).build();
-            });
-    }
-
-    /**
      * The class will communicate with the cache to fetch the credentials.
      * By default, requests are routed directly to the cache to handle the credentials fetching.
      */
-    CompletableFuture<? extends AwsCredentialsIdentity> getCredentialsFromCache(AwsCredentialsIdentity credentials, Permission permission, String S3Prefix, String accountId) {
+    CompletableFuture<? extends AwsCredentialsIdentity> getCredentialsFromCache(AwsCredentialsIdentity credentials, Permission permission, String S3Prefix, String accountId, S3ControlAsyncClient s3ControlAsyncClient) {
 
         try {
-            return cache.getDataAccess(credentials, permission, S3Prefix, accountId).exceptionally(e -> {
+            return cache.getDataAccess(credentials, permission, S3Prefix, accountId, s3ControlAsyncClient).exceptionally(e -> {
                 SdkServiceException throwableException = unwrapAndBuildException(e);
                 if (shouldFallbackToDefaultCredentialsForThisCase(throwableException.statusCode(), throwableException)) return credentials;
                 throw throwableException;
@@ -237,16 +196,16 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
         }
     }
 
-    private void validateRequestParameters(ResolveIdentityRequest resolveIdentityRequest, String accountId, Privilege privilege, Boolean isCacheEnabled) {
+    private void validateRequestParameters(ResolveIdentityRequest resolveIdentityRequest, Privilege privilege, Boolean isCacheEnabled) {
         logger.debug(() -> "Validating the request parameters before sending a request to S3 Access grants!");
         S3AccessGrantsUtils.argumentNotNull(resolveIdentityRequest, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "request", "identity provider"));
-        S3AccessGrantsUtils.argumentNotNull(accountId, "Expecting account id to be configured on the plugin!");
         S3AccessGrantsUtils.argumentNotNull(privilege, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "privilege", "identity provider"));
         S3AccessGrantsUtils.argumentNotNull(isCacheEnabled, String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "cache setting", "identity provider"));
         Pattern pattern = Pattern.compile("s3://[a-z0-9.-]*");
         S3AccessGrantsUtils.argumentNotNull(resolveIdentityRequest.property(PREFIX_PROPERTY), String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "S3Prefix", "identity provider"));
         Validate.isTrue(pattern.matcher(resolveIdentityRequest.property(PREFIX_PROPERTY).toString()).find(), String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "S3Prefix", "identity provider"));
-        S3AccessGrantsUtils.argumentNotNull(resolveIdentityRequest.property(OPERATION_PROPERTY), String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "operation", "identity provider"));
+        S3AccessGrantsUtils.argumentNotNull(resolveIdentityRequest.property(BUCKET_LOCATION_PROPERTY), String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "request region", "identity provider"));
+        S3AccessGrantsUtils.argumentNotNull(resolveIdentityRequest.property(PERMISSION_PROPERTY), String.format(CONTACT_TEAM_MESSAGE_TEMPLATE, "permission", "identity provider"));
         logger.debug(() -> "Validation Complete. The request parameters can be forwarded to S3 Access grants!");
     }
 
@@ -297,10 +256,21 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
 
     /**
      * Fetches the caller accountID from the requester using STS.
+     * For every request, if the caller credentials have been used previously, the accountID resolved for that credentials will be returned.
+     * If a new set of credentials are being used, then a request will be forwarded to STS to fetch the caller accountID and cache it.
+     * Each Identity provider is only going to cache one set of credentials/accountID at any point of time.
+     * This should be a safe considering service clients can refer to only one set of credentials for each request.
      * @return a completableFuture containing response from STS.
      * */
-    CompletableFuture<GetCallerIdentityResponse> getCallerAccountID() {
-        logger.debug(() -> "requesting STS to fetch caller accountID!");
-        return stsAsyncClient.getCallerIdentity();
+    String getCallerAccountID(CompletableFuture<? extends AwsCredentialsIdentity> userCredentials) {
+        AwsCredentialsIdentity credentials = userCredentials.join();
+        if(credentials.equals(cachedCredentials)) {
+            logger.debug(() -> "caller account cached, avoiding sending requests to STS");
+            return cachedAccountId;
+        }
+        logger.debug(() -> "caller account not cached, requesting STS to fetch caller accountID!");
+        cachedAccountId = stsAsyncClient.getCallerIdentity().join().account();
+        cachedCredentials = credentials;
+        return cachedAccountId;
     }
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/internal/S3AccessGrantsUtils.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/internal/S3AccessGrantsUtils.java
@@ -15,7 +15,9 @@
 
 package software.amazon.awssdk.s3accessgrants.plugin.internal;
 
+import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.identity.spi.IdentityProperty;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3control.model.Privilege;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
@@ -28,12 +30,21 @@ public class S3AccessGrantsUtils {
     public static Logger logger = Logger.loggerFor("software.amazon.awssdk.s3accessgrants");
     public static final IdentityProperty PREFIX_PROPERTY = IdentityProperty.create(String.class, "S3Prefix");
     public static final IdentityProperty OPERATION_PROPERTY = IdentityProperty.create(String.class,"Operation");
+    public static final IdentityProperty BUCKET_LOCATION_PROPERTY = IdentityProperty.create(Region.class, "BucketLocation");
+
+    public static final IdentityProperty AUTH_EXCEPTIONS_PROPERTY = IdentityProperty.create(SdkServiceException.class, "AuthExceptions");
+
+    public static final IdentityProperty PERMISSION_PROPERTY = IdentityProperty.create(String.class, "PermissionProperty");
+
+    public static String CONTACT_TEAM_MESSAGE_TEMPLATE = "An internal exception has occurred. Valid %s was not passed to the %s. Please contact S3 access grants plugin team!";
 
     public static final Boolean DEFAULT_CACHE_SETTING = true;
 
     public static final Privilege DEFAULT_PRIVILEGE_FOR_PLUGIN = Privilege.DEFAULT;
 
     public static final Boolean DEFAULT_FALLBACK_SETTING = false;
+
+    public static final Boolean DEFAULT_CROSS_REGION_ACCESS_SETTING = false;
 
     public static void argumentNotNull(Object param, String message) {
         try{

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProviderTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProviderTests.java
@@ -16,21 +16,30 @@
 package software.amazon.awssdk.s3accessgrants.plugin;
 
 import org.assertj.core.api.Assertions;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import java.util.List;
 import java.util.ArrayList;
+
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ServiceClientConfiguration;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeProvider;
 import software.amazon.awssdk.services.s3.auth.scheme.S3AuthSchemeParams;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketResponse;
+import software.amazon.awssdk.services.s3control.model.Permission;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.OPERATION_PROPERTY;
-import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.PREFIX_PROPERTY;
+import static org.mockito.Mockito.any;
+import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGrantsUtils.*;
 
 
 public class S3AccessGrantsAuthSchemeProviderTests {
@@ -42,30 +51,49 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     private static List<AuthSchemeOption> authSchemeResolverResult;
     private static final String SIGNING_SCHEME = "aws.auth#sigv4";
 
-    @BeforeClass
-    public static void setUp() {
+    private S3Client s3client;
+
+    private static final Boolean DefaultCrossRegionAccess = false;
+
+    @Before
+    public void setUp() {
+        s3client = mock(S3Client.class);
         authSchemeResolverResult = new ArrayList<>();
         authSchemeResolverResult.add(AuthSchemeOption.builder().schemeId(SIGNING_SCHEME).build());
+        when(s3client.serviceClientConfiguration()).thenReturn(S3ServiceClientConfiguration.builder().region(Region.US_EAST_2).build());
+        when(s3client.headBucket(any(HeadBucketRequest.class))).thenReturn(HeadBucketResponse.builder().bucketRegion(Region.US_EAST_1.toString()).build());
     }
 
     @Test
     public void create_authSchemeProvider_with_no_DefaultAuthProvider() {
 
-       Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(null)).isInstanceOf(IllegalArgumentException.class);
+       Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(null, s3client, DefaultCrossRegionAccess)).isInstanceOf(IllegalArgumentException.class);
 
+    }
+
+    @Test
+    public void create_authSchemeProvider_with_no_s3client() {
+        S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
+        Assertions.assertThatThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, null, DefaultCrossRegionAccess)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void create_authSchemeProvider_with_no_cross_region_access_setting() {
+        S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
+        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, null));
     }
 
     @Test
     public void create_authSchemeProvider_with_valid_DefaultAuthProvider() {
         S3AuthSchemeProvider authSchemeProvider = S3AuthSchemeProvider.defaultProvider();
 
-        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider));
+        Assertions.assertThatNoException().isThrownBy(() -> new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess));
     }
 
     @Test
     public void call_authSchemeProvider_with_null_params() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = null;
 
         Assertions.assertThatThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
@@ -73,20 +101,97 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     }
 
     @Test
-    public void call_authSchemeProvider_with_valid_params_valid_bucket() {
+    public void call_authSchemeProvider_without_valid_region() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3Client mockS3Client = mock(S3Client.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, mockS3Client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
-        Assertions.assertThatNoException().isThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams));
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        when(mockS3Client.serviceClientConfiguration()).thenReturn(S3ServiceClientConfiguration.builder().build());
+        Assertions.assertThatThrownBy(() -> accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_valid_bucket_cross_region_access_disabled() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_valid_bucket_cross_region_access_enabled() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_1);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_valid_bucket_cross_region_access_enabled_cache_test() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_1);
+        verify(s3client, times(1)).headBucket(any(HeadBucketRequest.class));
+        //resending the request to verify if the cache already has the bucket region
+        accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_1);
+        verify(s3client, times(1)).headBucket(any(HeadBucketRequest.class));
+
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_invalid_bucket_operation_supported() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(null);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
+        Assertions.assertThatThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams)).isInstanceOf(IllegalArgumentException.class);
         verify(authSchemeProvider, times(1)).resolveAuthScheme(authSchemeParams);
+    }
+
+    @Test
+    public void call_authSchemeProvider_with_valid_params_invalid_bucket_operation_not_supported() {
+        S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, !DefaultCrossRegionAccess);
+        S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
+
+        when(authSchemeParams.bucket()).thenReturn(null);
+        when(authSchemeParams.operation()).thenReturn("ListBucket");
+        when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
+        List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
+        SdkServiceException e = (SdkServiceException) accessGrantsAuthSchemeResult.get(0).identityProperty(AUTH_EXCEPTIONS_PROPERTY);
+        Assertions.assertThat(e.getCause()).isInstanceOf(UnsupportedOperationException.class);
+        // head bucket calls should not be made if the user has not specified valid bucket name
+        verify(s3client, never()).headBucket(any(HeadBucketRequest.class));
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_null_key() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).key(null).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -94,16 +199,18 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/*");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(AUTH_EXCEPTIONS_PROPERTY)).isNull();
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_invokes_default_authSchemeProvider() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
 
         Assertions.assertThatNoException().isThrownBy(()->accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams));
         verify(authSchemeProvider, times(1)).resolveAuthScheme(authSchemeParams);
@@ -112,10 +219,11 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     @Test
     public void call_authSchemeProvider_with_valid_params_invokes_default_authSchemeProvider_returning_valid_result() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = mock(S3AuthSchemeParams.class);
 
         when(authSchemeParams.bucket()).thenReturn(BUCKET_NAME);
+        when(authSchemeParams.operation()).thenReturn("GetObject");
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
 
         Assertions.assertThat(accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams).get(0).schemeId()).isEqualTo(SIGNING_SCHEME);
@@ -125,7 +233,7 @@ public class S3AccessGrantsAuthSchemeProviderTests {
     @Test
     public void call_authSchemeProvider_with_valid_params_captures_all_params_on_auth_scheme() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).key(KEY).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -133,13 +241,14 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/test-key");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PERMISSION_PROPERTY)).isEqualTo(Permission.READ);
     }
 
     @Test
     public void call_authSchemeProvider_with_valid_params_captures_all_params_with_prefix_as_object_key_on_auth_scheme() {
         S3AuthSchemeProvider authSchemeProvider = mock(S3AuthSchemeProvider.class);
-        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider);
+        S3AccessGrantsAuthSchemeProvider accessGrantsAuthSchemeProvider = new S3AccessGrantsAuthSchemeProvider(authSchemeProvider, s3client, DefaultCrossRegionAccess);
         S3AuthSchemeParams authSchemeParams = S3AuthSchemeParams.builder().bucket(BUCKET_NAME).prefix(KEY).operation(OPERATION).build();
 
         when(authSchemeProvider.resolveAuthScheme(authSchemeParams)).thenReturn(authSchemeResolverResult);
@@ -147,7 +256,8 @@ public class S3AccessGrantsAuthSchemeProviderTests {
         List<AuthSchemeOption> accessGrantsAuthSchemeResult = accessGrantsAuthSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PREFIX_PROPERTY)).isEqualTo("s3://test-bucket/test-key");
-        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(OPERATION_PROPERTY)).isEqualTo(OPERATION);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(BUCKET_LOCATION_PROPERTY)).isEqualTo(Region.US_EAST_2);
+        Assertions.assertThat(accessGrantsAuthSchemeResult.get(0).identityProperty(PERMISSION_PROPERTY)).isEqualTo(Permission.READ);
     }
 
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -44,6 +44,7 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
     }
 
     @Test
@@ -51,6 +52,15 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableFallback(true).build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isTrue();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
+    }
+
+    @Test
+    public void create_access_grants_plugin_with_cross_region_access_specified() {
+        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableCrossRegionAccess(true).build();
+        Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
+        Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
+        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isTrue();
     }
 
     @Test
@@ -78,7 +88,6 @@ public class S3AccessGrantsPluginTests {
                .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                .credentialsProvider(DefaultCredentialsProvider.create())
                .region(Region.US_EAST_2);
-
 
        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
 
@@ -126,8 +135,7 @@ public class S3AccessGrantsPluginTests {
                 .region(null);
 
 
-        Assertions.assertThatThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration))
-                .isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
 
     }
 


### PR DESCRIPTION
*Issue #, if available:*
In the current design, a single instance of S3ControlClient configured to a single region (region specified by customer on the S3Client with the plugin). With this design changes, a builder will be passed on to the auth handlers. The auth handlers will handle the logic to configure the control client to the correct region and pass it to the cache layer.
Additionally, in the current scenario, an STS request is made for each S3 request to fetch the caller account. To avoid throttling STS, a cache mechanism is added to only send request to STS if the credentials/identity used for the requests is changed.

*Description of changes:*
* Modifying AuthScheme and IdentityHandlers to integrate BucketRegion cache and STS caching.
* Modifying AuthScheme to delegating identity property generation to only AuthSchemeProvider (recommended by AWS SDK)
* Modifying unit tests.

*Testing:*
This PR is part of a large subset of PR's. Changes have been tested by running
* Unit-tests
* Integration-tests
* Spinning multiple threads in parallel sharing a single instance of s3client to send requests supported by Access Grants.

*Coverage:*
plugin layer - 86%

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
