### PR TITLE
updating region extraction from headbucket headers, and adding logging for debugging

### DIFF
--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
@@ -134,7 +134,7 @@ public class S3AccessGrantsIntegrationTests {
         credentialsProvider = ProfileCredentialsProvider.builder().profileName(S3AccessGrantsIntegrationTestsUtils.TEST_CREDENTIALS_PROFILE_NAME).build();
         s3ControlAsyncClientBuilder = S3AccessGrantsIntegrationTestsUtils.s3ControlAsyncClientBuilder(credentialsProvider, S3AccessGrantsIntegrationTestsUtils.TEST_REGION);
         s3Client = S3AccessGrantsIntegrationTestsUtils.s3ClientBuilder(credentialsProvider, S3AccessGrantsIntegrationTestsUtils.TEST_REGION);
-        authSchemeProvider = new S3AccessGrantsAuthSchemeProvider(S3AuthSchemeProvider.defaultProvider(), s3Client, true);
+        authSchemeProvider = new S3AccessGrantsAuthSchemeProvider(S3AuthSchemeProvider.defaultProvider(), s3Client, false);
         stsAsyncClient = StsAsyncClient.builder()
                 .credentialsProvider(credentialsProvider)
                 .region(S3AccessGrantsIntegrationTestsUtils.TEST_REGION)
@@ -377,8 +377,7 @@ public class S3AccessGrantsIntegrationTests {
     @Test
     public void call_s3_without_an_access_grant_request_failure_fallback_to_policy_evaluation() throws Exception {
 
-        S3AccessGrantsCachedCredentialsProviderImpl cache = spy(S3AccessGrantsCachedCredentialsProviderImpl.builder()
-                .build());
+        S3AccessGrantsCachedCredentialsProviderImpl cache = mock(S3AccessGrantsCachedCredentialsProviderImpl.class);
 
         S3AccessGrantsIdentityProvider identityProvider =
                 spy(new S3AccessGrantsIdentityProvider(credentialsProvider,
@@ -390,6 +389,8 @@ public class S3AccessGrantsIntegrationTests {
                         !S3AccessGrantsIntegrationTestsUtils.DEFAULT_FALLBACK_ENABLED,
                         metricPublisher,
                         clientsCache));
+
+        when(cache.getDataAccess(any(), any(), any(), any(), any())).thenThrow(S3ControlException.builder().statusCode(403).message("Access denied").build());
 
         S3Client s3Client = S3AccessGrantsIntegrationTestsUtils.s3clientBuilder(authSchemeProvider, identityProvider, S3AccessGrantsIntegrationTestsUtils.TEST_REGION);
 
@@ -482,8 +483,7 @@ public class S3AccessGrantsIntegrationTests {
     @Test
     public void call_s3_with_non_existent_location_request_failure_fallback_to_policy_evaluation() throws Exception {
 
-        S3AccessGrantsCachedCredentialsProvider cache = spy(S3AccessGrantsCachedCredentialsProviderImpl.builder()
-                .build());
+        S3AccessGrantsCachedCredentialsProvider cache = mock(S3AccessGrantsCachedCredentialsProviderImpl.class);
 
         S3AccessGrantsIdentityProvider identityProvider =
                 spy(new S3AccessGrantsIdentityProvider(credentialsProvider,
@@ -495,6 +495,8 @@ public class S3AccessGrantsIntegrationTests {
                         !S3AccessGrantsIntegrationTestsUtils.DEFAULT_FALLBACK_ENABLED,
                         metricPublisher,
                         clientsCache));
+
+        when(cache.getDataAccess(any(), any(), any(), any(), any())).thenThrow(S3ControlException.builder().statusCode(403).message("Access denied").build());
 
         S3Client s3Client = S3AccessGrantsIntegrationTestsUtils.s3clientBuilder(authSchemeProvider, identityProvider, S3AccessGrantsIntegrationTestsUtils.TEST_REGION);
 

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedCredentialsProviderImpl.java
@@ -22,6 +22,7 @@ import org.assertj.core.util.VisibleForTesting;
 import software.amazon.awssdk.annotations.NotNull;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.identity.spi.AwsSessionCredentialsIdentity;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.metrics.internal.DefaultMetricCollector;
 import software.amazon.awssdk.services.s3control.S3ControlAsyncClient;

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsAuthSchemeProvider.java
@@ -81,6 +81,7 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
         List<AuthSchemeOption> availableAuthSchemes = authSchemeProvider.resolveAuthScheme(authSchemeParams);
 
         try {
+            logger.debug(() -> "operation : " + authSchemeParams.operation());
             final Permission permission = permissionMapper.getPermission(authSchemeParams.operation());
 
             S3AccessGrantsUtils.argumentNotNull(authSchemeParams.bucket(), "Please specify a valid bucket name for the operation!");
@@ -88,7 +89,6 @@ public class S3AccessGrantsAuthSchemeProvider implements S3AuthSchemeProvider {
             final Region destinationRegion = getBucketLocation(authSchemeParams.bucket());
 
             logger.debug(() -> "Access Grants requests will be sent to the region "+destinationRegion);
-            logger.debug(() -> "operation : " + authSchemeParams.operation());
 
             String S3Prefix = "s3://"+authSchemeParams.bucket()+"/"+getKeyIfExists(authSchemeParams);
 

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIdentityProvider.java
@@ -158,6 +158,7 @@ public class S3AccessGrantsIdentityProvider implements IdentityProvider<AwsCrede
 
         } catch(SdkServiceException e) {
 
+            unwrapAndBuildException(e);
             if(shouldFallbackToDefaultCredentialsForThisCase(e.statusCode(), e.getCause())) {
                 return credentialsProvider.resolveIdentity(resolveIdentityRequest);
             }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -76,6 +76,7 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
     public void configureClient(SdkServiceClientConfiguration.Builder config) {
         logger.info(() -> "Configuring S3 Clients to use S3 Access Grants as a permission layer!");
         logger.info(() -> "Running the S3 Access grants plugin with fallback setting enabled : "+enableFallback());
+        logger.info(() -> "Running the S3 Access grants plugin with cross-region setting enabled : "+enableCrossRegionAccess());
         if(!enableFallback()) {
             logger.warn(() -> "Fallback not opted in! S3 Client will not fall back to evaluate policies if permissions are not provided through S3 Access Grants!");
         }


### PR DESCRIPTION
*Issue #, if available:*
Currently, the region for a bucket will only be extracted if the head bucket request is successful. However, S3 returns bucket region as a response header for failure cases. Adding logic to extract the region from headers if there is an exception and if the header contains the region.

*Description of changes:*
* Modifying logic to extract region from the head bucket response headers.
* Refactoring logging statements to ensure that better information is available during debugging.
* Updating unit and integration tests that failed with the head bucket response changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
