### PR TITLE
adding support to read cross-region setting from S3 Clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.s3.accessgrants</groupId>
     <artifactId>aws-s3-accessgrants-java-plugin</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>The Amazon Web Services Plugin for S3 Access Grants. The plugin allows customers to integrate S3 Access grants as an additional permission layer on top of S3 calls.</description>
@@ -41,7 +41,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sdk.version>2.22.3</sdk.version>
+        <sdk.version>2.23.7</sdk.version>
     </properties>
 
     <scm>
@@ -173,8 +173,93 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactSet>
+                                        <includes>
+                                            <include>software.amazon.s3.accessgrants:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactSet>
+                                        <includes>
+                                            <include>software.amazon.awssdk.s3accessgrants:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>log4j2.properties</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>software.amazon.awssdk.s3accessgrants:*</include>
+                                    <include>com.github.ben-manes.caffeine:*</include>
+                                    <include>com.google:*</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>log4j2.properties</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
+++ b/src/it/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsIntegrationTests.java
@@ -837,7 +837,7 @@ public class S3AccessGrantsIntegrationTests {
         ProfileCredentialsProvider credentialsProvider = ProfileCredentialsProvider.builder().profileName(S3AccessGrantsIntegrationTestsUtils.TEST_CREDENTIALS_PROFILE_NAME).build();
 
         S3AccessGrantsPlugin accessGrantsPlugin =
-                spy(S3AccessGrantsPlugin.builder().enableCrossRegionAccess(Boolean.TRUE).build());
+                spy(S3AccessGrantsPlugin.builder().build());
 
         S3Client s3Client =
                 S3Client.builder()

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/Builder.java
@@ -20,6 +20,5 @@ import software.amazon.awssdk.utils.builder.CopyableBuilder;
 
 public interface Builder extends CopyableBuilder<Builder, S3AccessGrantsPlugin> {
     Builder enableFallback(Boolean choice);
-
-    Builder enableCrossRegionAccess(Boolean choice);
+    
 }

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -134,8 +134,7 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
 
     /**
      * Extracts the cross region setting available on the S3 client!
-     * Returns Default setting if configuration is not captured by SDK. This is to ensure
-     * that non-cross-region calls work even with issues with SDK
+     * Returns Default setting if configuration is not specified on S3 Clients.
      * @param serviceClientConfiguration
      * @return
      */

--- a/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPlugin.java
@@ -45,11 +45,9 @@ import static software.amazon.awssdk.s3accessgrants.plugin.internal.S3AccessGran
 public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Builder, S3AccessGrantsPlugin> {
 
     private boolean enableFallback;
-    private boolean enableCrossRegionAccess;
 
     S3AccessGrantsPlugin(BuilderImpl builder) {
         this.enableFallback = builder.enableFallback;
-        this.enableCrossRegionAccess = builder.enableCrossRegionAccess;
     }
 
     public static Builder builder() {
@@ -64,10 +62,6 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
        return this.enableFallback;
     }
 
-    boolean enableCrossRegionAccess() {
-        return this.enableCrossRegionAccess;
-    }
-
     /**
      * Change the configuration on the S3Clients to use S3 Access Grants specific AuthScheme and identityProviders.
      * @param config the existing configuration on the clients. Passed by the SDK on request path.
@@ -76,20 +70,23 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
     public void configureClient(SdkServiceClientConfiguration.Builder config) {
         logger.info(() -> "Configuring S3 Clients to use S3 Access Grants as a permission layer!");
         logger.info(() -> "Running the S3 Access grants plugin with fallback setting enabled : "+enableFallback());
-        logger.info(() -> "Running the S3 Access grants plugin with cross-region setting enabled : "+enableCrossRegionAccess());
         if(!enableFallback()) {
             logger.warn(() -> "Fallback not opted in! S3 Client will not fall back to evaluate policies if permissions are not provided through S3 Access Grants!");
         }
-        if(!enableCrossRegionAccess()) {
-            logger.warn(() -> "cross-region access not opted in! S3 Client will not be able to communicate with buckets outside the configured region!");
-            logger.warn(() -> "Please turn-on cross region access on the plugin if you have turned on cross-region access settings on your S3 Client!");
-        }
-
         S3ServiceClientConfiguration.Builder serviceClientConfiguration =
                 Validate.isInstanceOf(S3ServiceClientConfiguration.Builder.class,
                         config,
                         "Expecting the plugin to be only "
                                 + "configured on s3 clients");
+
+        Boolean enableCrossRegionAccess = fetchFallbackConfiguration(serviceClientConfiguration);
+
+        logger.info(() -> "Running the S3 Access grants plugin with cross-region setting enabled : "+enableCrossRegionAccess);
+
+        if(!enableCrossRegionAccess) {
+            logger.warn(() -> "cross-region access not opted in! S3 Client will not be able to communicate with buckets outside the configured region!");
+            logger.warn(() -> "Please turn-on cross region access on the plugin if you have turned on cross-region access settings on your S3 Client!");
+        }
 
         S3ControlAsyncClientBuilder s3ControlAsyncClientBuilder = S3ControlAsyncClient.builder()
                 .credentialsProvider(serviceClientConfiguration.credentialsProvider());
@@ -135,22 +132,32 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
 
     }
 
+    /**
+     * Extracts the cross region setting available on the S3 client!
+     * Returns Default setting if configuration is not captured by SDK. This is to ensure
+     * that non-cross-region calls work even with issues with SDK
+     * @param serviceClientConfiguration
+     * @return
+     */
+    private Boolean fetchFallbackConfiguration(S3ServiceClientConfiguration.Builder serviceClientConfiguration) {
+        return serviceClientConfiguration.crossRegionAccessEnabled() != null ?
+                serviceClientConfiguration.crossRegionAccessEnabled() : DEFAULT_CROSS_REGION_ACCESS_SETTING;
+    }
+
     @Override
     public Builder toBuilder() {
         return new BuilderImpl(this);
     }
 
-    public static final class BuilderImpl implements Builder{
+    public static final class BuilderImpl implements Builder {
+
         private boolean enableFallback;
-        private boolean enableCrossRegionAccess;
         BuilderImpl() {
             this.enableFallback = DEFAULT_FALLBACK_SETTING;
-            this.enableCrossRegionAccess = DEFAULT_CROSS_REGION_ACCESS_SETTING;
         }
 
         BuilderImpl(S3AccessGrantsPlugin plugin) {
             this.enableFallback = plugin.enableFallback;
-            this.enableCrossRegionAccess = plugin.enableCrossRegionAccess;
         }
 
         @Override
@@ -162,12 +169,6 @@ public class S3AccessGrantsPlugin  implements SdkPlugin, ToCopyableBuilder<Build
         public Builder enableFallback(@NotNull Boolean choice) {
            this.enableFallback = choice == null ? DEFAULT_FALLBACK_SETTING: choice;
            return this;
-        }
-
-        @Override
-        public Builder enableCrossRegionAccess(@NotNull Boolean choice) {
-            this.enableCrossRegionAccess = choice == null ? DEFAULT_CROSS_REGION_ACCESS_SETTING: choice;
-            return this;
         }
     }
 }

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -88,7 +88,6 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                .credentialsProvider(DefaultCredentialsProvider.create())
-                .crossRegionAccessEnabled(true)
                .region(Region.US_EAST_2);
 
        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
@@ -102,7 +101,6 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(null)
                 .credentialsProvider(DefaultCredentialsProvider.create())
-                .crossRegionAccessEnabled(true)
                 .region(Region.US_EAST_2);
 
 
@@ -119,7 +117,6 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                 .credentialsProvider(null)
-                .crossRegionAccessEnabled(true)
                 .region(Region.US_EAST_2);
 
 
@@ -136,7 +133,6 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                 .credentialsProvider(DefaultCredentialsProvider.create())
-                .crossRegionAccessEnabled(true)
                 .region(null);
 
 

--- a/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
+++ b/src/test/java/software/amazon/awssdk/s3accessgrants/plugin/S3AccessGrantsPluginTests.java
@@ -44,7 +44,6 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
-        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
     }
 
     @Test
@@ -52,15 +51,6 @@ public class S3AccessGrantsPluginTests {
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableFallback(true).build();
         Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
         Assertions.assertThat(accessGrantsPlugin.enableFallback()).isTrue();
-        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isFalse();
-    }
-
-    @Test
-    public void create_access_grants_plugin_with_cross_region_access_specified() {
-        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().enableCrossRegionAccess(true).build();
-        Assertions.assertThatNoException().isThrownBy(() -> S3AccessGrantsPlugin.builder(accessGrantsPlugin));
-        Assertions.assertThat(accessGrantsPlugin.enableFallback()).isFalse();
-        Assertions.assertThat(accessGrantsPlugin.enableCrossRegionAccess()).isTrue();
     }
 
     @Test
@@ -81,12 +71,24 @@ public class S3AccessGrantsPluginTests {
     }
 
     @Test
+    public void call_configure_client_with_valid_config_null_cross_region_setting() {
+        S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
+        SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
+                .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .crossRegionAccessEnabled(null)
+                .region(Region.US_EAST_2);
+        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
+    }
+
+    @Test
     public void call_configure_client_with_valid_config() {
 
         S3AccessGrantsPlugin accessGrantsPlugin = S3AccessGrantsPlugin.builder().build();
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                .credentialsProvider(DefaultCredentialsProvider.create())
+                .crossRegionAccessEnabled(true)
                .region(Region.US_EAST_2);
 
        Assertions.assertThatNoException().isThrownBy(() -> accessGrantsPlugin.configureClient(sdkServiceClientConfiguration));
@@ -100,6 +102,7 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(null)
                 .credentialsProvider(DefaultCredentialsProvider.create())
+                .crossRegionAccessEnabled(true)
                 .region(Region.US_EAST_2);
 
 
@@ -116,6 +119,7 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                 .credentialsProvider(null)
+                .crossRegionAccessEnabled(true)
                 .region(Region.US_EAST_2);
 
 
@@ -132,6 +136,7 @@ public class S3AccessGrantsPluginTests {
         SdkServiceClientConfiguration.Builder sdkServiceClientConfiguration = S3ServiceClientConfiguration.builder()
                 .authSchemeProvider(S3AuthSchemeProvider.defaultProvider())
                 .credentialsProvider(DefaultCredentialsProvider.create())
+                .crossRegionAccessEnabled(true)
                 .region(null);
 
 


### PR DESCRIPTION
*Issue #, if available:*
Updating logic to read the cross-region configuration from the S3 Client.

*Description of changes:*
* Customers no longer need to specify a separate setting for cross-region on the plugin
* updating pom files to ignore release log4j configuration in public releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
