### PR TITLE
adding comment to remind to bumb version in SDK bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
 
     <groupId>software.amazon.s3.accessgrants</groupId>
     <artifactId>aws-s3-accessgrants-java-plugin</artifactId>
+    <!-- This plugin is also shipped as part of AWS SDK Bundle. Please update the plugin version shipped within AWS SDK bundle-->
     <version>2.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
*Issue #, if available:*
The plugin will now be shipped as part of AWS SDK Bundle. Adding a comment in the plugin pom.xml to remind bumping the version in SDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
