### PR TITLE
updating README to reflect the cross-region settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The plugin by default does not support cross-region access of S3 Buckets/data.
 In order to turn on the cross-region support, please configure the S3Client to support cross-region access. The plugin will default to the cross-region setting on the S3Client.
 
 ```
-
+example - 
         S3AccessGrantsPlugin accessGrantsPlugin =
                 S3AccessGrantsPlugin.builder().build();
                 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The plugin by default does not support cross-region access of S3 Buckets/data.
 In order to turn on the cross-region support, please configure the S3Client to support cross-region access. The plugin will default to the cross-region setting on the S3Client.
 
 ```
+
+        S3AccessGrantsPlugin accessGrantsPlugin =
+                S3AccessGrantsPlugin.builder().build();
+                
         S3Client s3Client =
                 S3Client.builder()
                         .crossRegionAccessEnabled(true)

--- a/README.md
+++ b/README.md
@@ -68,12 +68,9 @@ Using this S3Client to make API calls, you should be able to use Access Grants t
 ### Turn on cross-region access
 
 The plugin by default does not support cross-region access of S3 Buckets/data. 
-In order to turn on the cross-region support, please configure S3Client and Access Grants Plugin to support cross-region access.
+In order to turn on the cross-region support, please configure the S3Client to support cross-region access. The plugin will default to the cross-region setting on the S3Client.
 
 ```
- S3AccessGrantsPlugin accessGrantsPlugin =
-                S3AccessGrantsPlugin.builder().enableCrossRegionAccess(Boolean.TRUE).build();
-
         S3Client s3Client =
                 S3Client.builder()
                         .crossRegionAccessEnabled(true)
@@ -82,9 +79,6 @@ In order to turn on the cross-region support, please configure S3Client and Acce
                         .region(S3AccessGrantsIntegrationTestsUtils.TEST_REGION)
                         .build();
 ```
-
-#### NOTE - 
-If cross-region access setting is turned on for either the S3 Client or the plugin (but not both), you might experience bucket region mismatch errors.
 
 ### Cross-account support
 


### PR DESCRIPTION
*Issue #, if available:*
The plugin now does not require to explicitly specify the cross-region setting. The plugin will directly pull the setting from the S3Client it is attached to.

*Description of changes:*
* updating README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
