### PR TITLE
Fix S3 Access Grants SDK Java Plugin Leads To Higher API Calls In MultiThreaded Environment

### DIFF
--- a/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
+++ b/src/main/java/software/amazon/awssdk/s3accessgrants/cache/S3AccessGrantsCachedAccountIdResolver.java
@@ -73,16 +73,13 @@ public class S3AccessGrantsCachedAccountIdResolver implements S3AccessGrantsAcco
     @Override
     public String resolve(String accountId, String s3Prefix, S3ControlAsyncClient s3ControlAsyncClient) {
         String bucketName = getBucketName(s3Prefix);
-        String s3PrefixAccountId = cache.getIfPresent(bucketName);
-        if (s3PrefixAccountId == null) {
+        return cache.get(bucketName, key -> {
             logger.debug(()->"Account Id not available in the cache. Fetching account from server.");
             if (s3ControlAsyncClient == null) {
                 throw new IllegalArgumentException("S3ControlAsyncClient is required for the access grants instance account resolver!");
             }
-            s3PrefixAccountId = resolveFromService(accountId, s3Prefix, s3ControlAsyncClient);
-            cache.put(bucketName, s3PrefixAccountId);
-        }
-        return s3PrefixAccountId;
+            return resolveFromService(accountId, s3Prefix, s3ControlAsyncClient);
+        });
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*

In a multi-threaded environment like EMR Spark - where multiple threads access a S3 path (under a single access grant prefix) using the same S3 client is using higher number of GetCallerIdentity , GetAccessGrantsInstanceForPrefix and GetDataAccess API calls as compared to sequential execution. This leads to API throttling at the customers side when there are large number of concurrent tasks which is a very common use case in Analytical world.

This commit fixes them by handling the cache population synchronously.

1. S3AccessGrantsCache Fix
   • **Problem**: Multiple GetDataAccess calls
   • **Solution**: Double-checked locking with synchronized(this)

2. S3AccessGrantsCachedAccountIdResolver Fix
   • **Problem**: Multiple GetAccessGrantsInstanceForPrefix calls
   • **Solution**: Atomic cache.get(key, loader) operation

3. S3AccessGrantsIdentityProvider Fix
   • **Problem**: Multiple GetCallerIdentity calls  
   • **Solution**: Double-checked locking with volatile fields and synchronized block



`[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 110, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.575 s
[INFO] Finished at: 2025-08-13T11:53:22+05:30`




