### PR TITLE
updating jobs worklfow due to recent permission related failures

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -18,6 +18,8 @@ jobs:
   build:
 
     runs-on: ${{matrix.os}}
+    permissions:
+      contents: write
     strategy:
        matrix:
           os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -35,4 +37,4 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
*Description of changes:*
Adding Job level permissions for the dependency graph update actions. This action is required to update the dependency graph and is later used by depandabot for automated dependency updates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
